### PR TITLE
Make the `tests` target of the Makefile `PHONY`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -15,29 +15,38 @@ PREFIX=TPTP
 RELEASE=
 SHUTUP=
 ifdef RELEASE
-	SHUTUP=2>/dev/null 
+	SHUTUP=2>/dev/null
 	GOFLAGS=-gcflags=-m
 endif
 
 # Parse files
 PROB=../../problems/SYN
+TMPFILE=/tmp/GOELAND_TESTS_OK
 
-all: 
+all:
 	$(GOYACC) $(GOYACCFLAGS) -p $(PREFIX) -o $(GOPARSER) $(YACCFILE); \
-	$(GOC) $(GOFLAGS) -o $(BIN) $(GOSRC) 
+	$(GOC) $(GOFLAGS) -o $(BIN) $(GOSRC)
 
 static-linux-release:
 	$(GOYACC) $(GOYACCFLAGS) -p $(PREFIX) -o $(GOPARSER) $(YACCFILE); \
 	GOOS=linux GOARCH=amd64 $(GOC) -tags osusergo,netgo -ldflags="-extldflags=-static" -o $(BIN)_linux_release $(GOSRC)
-	
+
 parse:
 	@for i in `ls $(PROB)/*.p`; do echo -e "File \033[32m$$i\033[39m: "; \
         ./$(BIN) $$i; echo; done
 
 clean:
-	rm -f *~ $(GOPARSER) y.output  
+	rm -f *~ $(GOPARSER) y.output
 	rm -rf $(BUILD)
 	rm goeland.vo* goeland.glob
 
+.PHONY: tests
 tests:
-	go test -v -coverprofile=coverage.out ./... || (go tool cover -html=coverage.out && rm coverage.out)
+	go test -v -coverprofile=coverage.out ./... && touch $(TMPFILE) || /bin/true
+	go tool cover -html=coverage.out -o _build/coverage.html && rm coverage.out
+	if [ -f $(TMPFILE) ]; then \
+		rm -f $(TMPFILE); \
+		exit 0; \
+	else \
+		exit 1; \
+	fi


### PR DESCRIPTION
While filing #13, I found out that `make tests` reported that the target "tests" was up-to-date.

Added this target to be phony (i.e., always executed). I also took the opportunity to improve the code executed by `make tests`, which now saves the coverage results inside the `_build` folder instead of saving it in `/tmp/` and opening it in a browser.