### PR TITLE
Add a `Makefile` in `devtools` to easily run the full ci in local

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,13 +17,11 @@ them. The current maintainers are: @jcailler, @jrosain.
 Your code is expected to (i) build, (ii) satisfy the unit tests and (iii) not
 prove countertheorems. This check *does not* run automatically. One of the
 maintainers will trigger the CI when he sees fit. You may check soundness
-locally by running the
-[SOUNDNESS](https://github.com/GoelandProver/GoelandBenchmarks/tree/main/SOUNDNESS)
-benchmarks (see the [README](README.md#running-benchmarks) for more explanations
-on running benchmarks). Note that it is **not** the maintainer's responsibility
-to make your modifications compatible with the master's branch. If there are any
-conflicts, you are expected to solve them by *rebasing your branch on top of
-upstream's master*.
+locally by running the `ci-soundness` target of the [devtools](devtools)
+folder. Note that it is **not** the maintainer's responsibility to make your
+modifications compatible with the master's branch. If there are any conflicts,
+you are expected to solve them by *rebasing your branch on top of upstream's
+master*.
 
 If you are solving a bug referenced in the issue tracker, do not forget to link
 it in the PR.

--- a/devtools/Makefile
+++ b/devtools/Makefile
@@ -1,0 +1,6 @@
+ci-soundness:
+	cd ../src && make
+	python3 run_soundness_tests.py ../.github/soundness 120
+	python3 run_soundness_tests.py ../.github/soundness 120 -inner
+	python3 run_soundness_tests.py ../.github/soundness 120 -preinner
+	python3 run_soundness_tests.py ../.github/soundness 120 -dmt


### PR DESCRIPTION
As such, if the full ci fails in the actions, one can execute it locally and see what breaks if there's not enough information on the action report.