### PR TITLE
CI: run the `enforce-label` job on unlabeled event 

### DIFF
--- a/.github/workflows/pr-merge-fail-if-needs-ci.yml
+++ b/.github/workflows/pr-merge-fail-if-needs-ci.yml
@@ -2,7 +2,7 @@ name: Enforce CI run before merging
 
 on:
   pull_request:
-    types: [labeled]
+    types: [labeled, unlabeled]
 
 jobs:
   enforce-label:


### PR DESCRIPTION
As seen in #26, it only runs on `labeled` which is annoying.