### PR TITLE
Make second argument of `PrintDebug` lazy

### DIFF
--- a/src/AST/typearrow.go
+++ b/src/AST/typearrow.go
@@ -108,7 +108,10 @@ func (ta TypeArrow) GetPrimitives() []TypeApp {
 /* Makes a TypeArrow from two TypeSchemes */
 func MkTypeArrow(left TypeApp, typeApps ...TypeApp) TypeArrow {
 	if len(typeApps) < 1 {
-		Glob.PrintDebug("MKTA", "There should be at least one out type in a TypeArrow.")
+		Glob.PrintDebug(
+			"MKTA",
+			Lib.MkLazy(func() string { return "There should be at least one out type in a TypeArrow." }),
+		)
 		return TypeArrow{}
 	}
 	ta := TypeArrow{left: left, right: make(Lib.ComparableList[TypeApp], len(typeApps))}

--- a/src/AST/typecross.go
+++ b/src/AST/typecross.go
@@ -120,7 +120,10 @@ func (tc TypeCross) GetAllUnderlyingTypes() []TypeApp {
  **/
 func MkTypeCross(typeSchemes ...TypeApp) TypeCross {
 	if len(typeSchemes) < 2 {
-		Glob.PrintDebug("MKTC", "There should be at least two underlying types in a TypeCross.")
+		Glob.PrintDebug(
+			"MKTC",
+			Lib.MkLazy(func() string { return "There should be at least two underlying types in a TypeCross." }),
+		)
 		return TypeCross{}
 	}
 	tc := TypeCross{types: make([]TypeApp, len(typeSchemes))}

--- a/src/Core/FormListDS.go
+++ b/src/Core/FormListDS.go
@@ -34,6 +34,7 @@ package Core
 import (
 	"github.com/GoelandProver/Goeland/AST"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Unif"
 )
 
@@ -70,7 +71,7 @@ func (f FormListDS) InsertFormulaListToDataStructure(lf *AST.FormList) Unif.Data
 
 func (f FormListDS) Print() {
 	for _, f := range f.GetFL().Slice() {
-		Glob.PrintDebug("FLTS", f.ToString())
+		Glob.PrintDebug("FLTS", Lib.MkLazy(func() string { return f.ToString() }))
 	}
 }
 

--- a/src/Core/form_and_terms_list.go
+++ b/src/Core/form_and_terms_list.go
@@ -85,7 +85,7 @@ func (fl FormAndTermsList) ToString() string {
 /* Print a list of formulas */
 func (lf FormAndTermsList) Print() {
 	for _, f := range lf {
-		Glob.PrintDebug("FLTS", f.GetForm().ToString())
+		Glob.PrintDebug("FLTS", Lib.MkLazy(func() string { return f.GetForm().ToString() }))
 	}
 }
 

--- a/src/Core/global_unifier.go
+++ b/src/Core/global_unifier.go
@@ -133,7 +133,7 @@ func (u Unifier) GetUnifier() Unif.Substitutions {
 	if !Glob.GetProof() || len(u.localUnifiers) == 0 {
 		return Unif.MakeEmptySubstitution()
 	}
-	Glob.PrintDebug("UNIFS", u.ToString())
+	Glob.PrintDebug("UNIFS", Lib.MkLazy(func() string { return u.ToString() }))
 	if len(u.localUnifiers) > 0 && len(u.localUnifiers[0].Snd) > 0 {
 		return u.localUnifiers[0].Snd[0]
 	}
@@ -162,7 +162,10 @@ func (u *Unifier) Merge(other Unifier) {
 		return
 	}
 
-	Glob.PrintDebug("GLOBAL UNIFIER", fmt.Sprintf("Current: %s, to merge: %s", u.ToString(), other.ToString()))
+	Glob.PrintDebug(
+		"GLOBAL UNIFIER",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Current: %s, to merge: %s", u.ToString(), other.ToString()) }),
+	)
 
 	newUnifiers := []Glob.Pair[substitutions, []substitutions]{}
 
@@ -191,7 +194,7 @@ func (u *Unifier) Merge(other Unifier) {
 		}
 	}
 	u.localUnifiers = newUnifiers
-	Glob.PrintDebug("GLOBAL UNIFIER", fmt.Sprintf("After: %s", u.ToString()))
+	Glob.PrintDebug("GLOBAL UNIFIER", Lib.MkLazy(func() string { return fmt.Sprintf("After: %s", u.ToString()) }))
 }
 
 func (u *Unifier) PruneMetasInSubsts(metas Lib.Set[AST.Meta]) {

--- a/src/Core/meta_gen.go
+++ b/src/Core/meta_gen.go
@@ -41,6 +41,7 @@ import (
 	"strconv"
 
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 )
 
 /**
@@ -133,7 +134,10 @@ func getAllLessReintroducedMeta(meta_generator []MetaGen, allowed_indexes []int)
 	min := -1
 	saved_indexes := []int{}
 	for i, v := range meta_generator {
-		Glob.PrintDebug("PS", fmt.Sprintf("v.getCounter : %d - Min : %d", v.GetCounter(), min))
+		Glob.PrintDebug(
+			"PS",
+			Lib.MkLazy(func() string { return fmt.Sprintf("v.getCounter : %d - Min : %d", v.GetCounter(), min) }),
+		)
 		if (allowed_indexes == nil || Glob.ContainsInt(i, allowed_indexes)) && ((v.GetCounter() <= min) || min == -1) {
 			new_min := v.GetCounter()
 			if new_min < min || min == -1 {
@@ -143,7 +147,7 @@ func getAllLessReintroducedMeta(meta_generator []MetaGen, allowed_indexes []int)
 				saved_indexes = Glob.AppendIfNotContainsInt(saved_indexes, i)
 			}
 		}
-		Glob.PrintDebug("PS", fmt.Sprintf("Min after : %d", min))
+		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("Min after : %d", min) }))
 	}
 	return saved_indexes
 }
@@ -168,7 +172,14 @@ func ReintroduceMeta(meta_generator *[]MetaGen, index int, limit int) FormAndTer
 /* reintroduce the given meta iff is it part of the less reintroduced ones */
 func ReintroduceMetaIfLessReintroduced(meta_generator *[]MetaGen, index int) FormAndTerms {
 	indexes_less_reintroduced_meta := getAllLessReintroducedMeta(*meta_generator, nil)
-	Glob.PrintDebug("PS", fmt.Sprintf("Less reintroduced metas : %s", Glob.IntListToString(indexes_less_reintroduced_meta)))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Less reintroduced metas : %s",
+				Glob.IntListToString(indexes_less_reintroduced_meta))
+		}),
+	)
 	index_less_reintroduced_meta := -1
 	if Glob.ContainsInt(index, indexes_less_reintroduced_meta) {
 		index_less_reintroduced_meta = index

--- a/src/Core/substitutions_search.go
+++ b/src/Core/substitutions_search.go
@@ -66,10 +66,12 @@ func GetMetaFromSubst(subs Unif.Substitutions) Lib.Set[AST.Meta] {
 
 /* Remove substitution without mm */
 func RemoveElementWithoutMM(subs Unif.Substitutions, mm Lib.Set[AST.Meta]) Unif.Substitutions {
-	Glob.PrintDebug("REWM", fmt.Sprintf(
-		"MM : %v",
-		Lib.ListToString(mm.Elements(), ",", "[]"),
-	))
+	Glob.PrintDebug("REWM", Lib.MkLazy(func() string {
+		return fmt.Sprintf(
+			"MM : %v",
+			Lib.ListToString(mm.Elements(), ",", "[]"),
+		)
+	}))
 
 	res := Unif.Substitutions{}
 
@@ -79,10 +81,12 @@ func RemoveElementWithoutMM(subs Unif.Substitutions, mm Lib.Set[AST.Meta]) Unif.
 
 	for hasChanged {
 		hasChanged = false
-		Glob.PrintDebug("REWM", fmt.Sprintf(
-			"Relevant meta : %v",
-			Lib.ListToString(relevantMetas.Elements(), ",", "[]"),
-		))
+		Glob.PrintDebug("REWM", Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Relevant meta : %v",
+				Lib.ListToString(relevantMetas.Elements(), ",", "[]"),
+			)
+		}))
 		for _, singleSubs := range subs {
 			meta, term := singleSubs.Get()
 
@@ -112,15 +116,28 @@ func RemoveElementWithoutMM(subs Unif.Substitutions, mm Lib.Set[AST.Meta]) Unif.
 		}
 	}
 
-	Glob.PrintDebug("REWM", fmt.Sprintf("Subst intermédiaire res : %v", res.ToString()))
-	Glob.PrintDebug("REWM", fmt.Sprintf("Subst intermédiaire subst_to_reorganize  : %v", subsToReorganize.ToString()))
+	Glob.PrintDebug(
+		"REWM",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Subst intermédiaire res : %v", res.ToString()) }),
+	)
+	Glob.PrintDebug(
+		"REWM",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Subst intermédiaire subst_to_reorganize  : %v",
+				subsToReorganize.ToString())
+		}),
+	)
 
 	subsToReorganize = ReorganizeSubstitution(subsToReorganize)
 	Unif.EliminateMeta(&subsToReorganize)
 	Unif.Eliminate(&subsToReorganize)
 	ms, _ := Unif.MergeSubstitutions(res, subsToReorganize)
 
-	Glob.PrintDebug("REWM", fmt.Sprintf("Finale subst : %v", ms.ToString()))
+	Glob.PrintDebug(
+		"REWM",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Finale subst : %v", ms.ToString()) }),
+	)
 
 	if ms.Equals(Unif.Failure()) {
 		Glob.PrintError("REWM", "MergeSubstitutions returns failure")

--- a/src/Glob/log.go
+++ b/src/Glob/log.go
@@ -37,6 +37,7 @@ package Glob
 
 import (
 	"fmt"
+	"github.com/GoelandProver/Goeland/Lib"
 	"io"
 	"log"
 	"os"
@@ -74,8 +75,8 @@ func InitLogs() {
 
 /* Sets the function to be called when PrintDebug is called. This way, we avoid an if test when not in debug mode. */
 func EnableDebug() {
-	PrintDebug = func(function, message string) {
-		printToLogger(logDebug, function, message)
+	PrintDebug = func(function string, message Lib.Lazy[string]) {
+		printToLogger(logDebug, function, message.Run())
 	}
 
 	getId = func() (options []any, str string) {
@@ -152,7 +153,7 @@ func EnableWriteLogs() {
 // Use when you want to display a message for debugging purposes only.
 // The prefix for debug messages is '[debug]' in blue.
 // Will only print in the terminal and/or the file if the corresponding options -debug and -dif have been set.
-var PrintDebug = func(function, message string) {}
+var PrintDebug = func(function string, message Lib.Lazy[string]) {}
 
 // Prints the message into the terminal and the file as an information message
 //

--- a/src/Lib/lazy.go
+++ b/src/Lib/lazy.go
@@ -1,0 +1,47 @@
+/**
+* Copyright 2022 by the authors (see AUTHORS).
+*
+* Goéland is an automated theorem prover for first order logic.
+*
+* This software is governed by the CeCILL license under French law and
+* abiding by the rules of distribution of free software.  You can  use,
+* modify and/ or redistribute the software under the terms of the CeCILL
+* license as circulated by CEA, CNRS and INRIA at the following URL
+* "http://www.cecill.info".
+*
+* As a counterpart to the access to the source code and  rights to copy,
+* modify and redistribute granted by the license, users are provided only
+* with a limited warranty  and the software's author,  the holder of the
+* economic rights,  and the successive licensors  have only  limited
+* liability.
+*
+* In this respect, the user's attention is drawn to the risks associated
+* with loading,  using,  modifying and/or developing or reproducing the
+* software by the user in light of its specific status of free software,
+* that may mean  that it is complicated to manipulate,  and  that  also
+* therefore means  that it is reserved for developers  and  experienced
+* professionals having in-depth computer knowledge. Users are therefore
+* encouraged to load and test the software's suitability as regards their
+* requirements in conditions enabling the security of their systems and/or
+* data to be ensured and,  more generally, to use and operate it in the
+* same conditions as regards security.
+*
+* The fact that you are presently reading this means that you have had
+* knowledge of the CeCILL license and that you accept its terms.
+**/
+
+package Lib
+
+/** This file provides a basic interface to use basic laziness. */
+
+type Lazy[T any] struct {
+	run func() T
+}
+
+func MkLazy[T any](run func() T) Lazy[T] {
+	return Lazy[T]{run}
+}
+
+func (lazy Lazy[T]) Run() T {
+	return lazy.run()
+}

--- a/src/Mods/assisted/rules.go
+++ b/src/Mods/assisted/rules.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/GoelandProver/Goeland/Core"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Unif"
 )
 
@@ -74,7 +75,10 @@ func applyAtomicRule(state Search.State, fatherId uint64, c Search.Communication
 	listSubsts := [][]Core.SubstAndForm{}
 	finalBool := true
 	for _, f := range state.GetAtomic() {
-		Glob.PrintDebug("Assisted", fmt.Sprintf("##### Formula %v #####", f.ToString()))
+		Glob.PrintDebug(
+			"Assisted",
+			Lib.MkLazy(func() string { return fmt.Sprintf("##### Formula %v #####", f.ToString()) }),
+		)
 
 		clos_res_after_apply_subst, subst_after_apply_subst := Search.ApplyClosureRules(f.GetForm(), &state)
 		if clos_res_after_apply_subst {
@@ -88,7 +92,12 @@ func applyAtomicRule(state Search.State, fatherId uint64, c Search.Communication
 	}
 
 	if !foundOne {
-		Glob.PrintDebug("ApplyAtomicRule", "No valid substitution found. This state will be copied and put back in the list.")
+		Glob.PrintDebug(
+			"ApplyAtomicRule",
+			Lib.MkLazy(func() string {
+				return "No valid substitution found. This state will be copied and put back in the list."
+			}),
+		)
 		assistedCounter.Increment()
 		go searchAlgo.ProofSearch(fatherId, state, c, substitut, nodeId, originalNodeId, metaToReintroduce, false)
 	} else {
@@ -111,9 +120,12 @@ func applyAtomicRule(state Search.State, fatherId uint64, c Search.Communication
 }
 
 func applyAlphaRule(state Search.State, indiceForm int, fatherId uint64, c Search.Communication, substitut Core.SubstAndForm, originalNodeId int) {
-	Glob.PrintDebug("PS", "User chose Alpha rule")
+	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "User chose Alpha rule" }))
 	hdf := state.GetAlpha()[indiceForm]
-	Glob.PrintDebug("PS", fmt.Sprintf("Rule applied on : %s", hdf.ToString()))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }),
+	)
 
 	state.SetAlpha(append(state.GetAlpha()[:indiceForm], state.GetAlpha()[indiceForm+1:]...))
 	result_forms := Search.ApplyAlphaRules(hdf, &state)
@@ -129,9 +141,9 @@ func applyAlphaRule(state Search.State, indiceForm int, fatherId uint64, c Searc
 }
 
 func applyBetaRule(state Search.State, substitut Core.SubstAndForm, c Search.Communication, fatherId uint64, nodeId int, originalNodeId int, metaToReintroduce []int) {
-	Glob.PrintDebug("PS", "User chose Beta rule")
+	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "User chose Beta rule" }))
 	hdf := state.GetBeta()[0]
-	Glob.PrintDebug("PS", fmt.Sprintf("Rule applied on : %s", hdf.ToString()))
+	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
 	reslf := Search.ApplyBetaRules(hdf, &state)
 	child_id_list := []int{}
 
@@ -165,7 +177,7 @@ func applyBetaRule(state Search.State, substitut Core.SubstAndForm, c Search.Com
 		}
 
 		Glob.IncrGoRoutine(1)
-		Glob.PrintDebug("PS", fmt.Sprintf("GO %v !", fl.GetI()))
+		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("GO %v !", fl.GetI()) }))
 
 	}
 
@@ -173,9 +185,12 @@ func applyBetaRule(state Search.State, substitut Core.SubstAndForm, c Search.Com
 }
 
 func applyDeltaRule(state Search.State, indiceForm int, fatherId uint64, c Search.Communication, substitut Core.SubstAndForm, originalNodeId int) {
-	Glob.PrintDebug("PS", "User chose Delta rule")
+	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "User chose Delta rule" }))
 	hdf := state.GetDelta()[indiceForm]
-	Glob.PrintDebug("PS", fmt.Sprintf("Rule applied on : %s", hdf.ToString()))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }),
+	)
 
 	state.SetDelta(append(state.GetDelta()[:indiceForm], state.GetDelta()[indiceForm+1:]...))
 	result_forms := Search.ApplyDeltaRules(hdf, &state)
@@ -191,9 +206,15 @@ func applyDeltaRule(state Search.State, indiceForm int, fatherId uint64, c Searc
 }
 
 func applyGammaRule(state Search.State, indiceForm int, fatherId uint64, c Search.Communication, substitut Core.SubstAndForm, originalNodeId int) {
-	Glob.PrintDebug("PS", "User chose Gamma rule")
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string { return "User chose Gamma rule" }),
+	)
 	hdf := state.GetGamma()[indiceForm]
-	Glob.PrintDebug("PS", fmt.Sprintf("Rule applied on : %s", hdf.ToString()))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }),
+	)
 	state.SetGamma(append(state.GetGamma()[:indiceForm], state.GetGamma()[indiceForm+1:]...))
 
 	index, new_meta_gen := Core.GetIndexMetaGenList(hdf, state.GetMetaGen())
@@ -219,11 +240,21 @@ func applyGammaRule(state Search.State, indiceForm int, fatherId uint64, c Searc
 }
 
 func applyReintroductionRule(state Search.State, fatherId uint64, c Search.Communication, originalNodeId int, metaToReintroduce []int, chosenReintro int) {
-	Glob.PrintDebug("PS", "Reintroduction")
-	Glob.PrintDebug("PS", fmt.Sprintf("Meta to reintroduce : %s", Glob.IntListToString(metaToReintroduce)))
+	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Reintroduction" }))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Meta to reintroduce : %s",
+				Glob.IntListToString(metaToReintroduce))
+		}),
+	)
 	newMetaGen := state.GetMetaGen()
 	reslf := Core.ReintroduceMeta(&newMetaGen, chosenReintro, state.GetN())
-	Glob.PrintDebug("PS", fmt.Sprintf("Reintroduce the formula : %s", reslf.ToString()))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Reintroduce the formula : %s", reslf.ToString()) }),
+	)
 	state.SetLF(Core.MakeSingleElementFormAndTermList(reslf))
 
 	state.SetMetaGen(newMetaGen)

--- a/src/Mods/assisted/status.go
+++ b/src/Mods/assisted/status.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/GoelandProver/Goeland/Core"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Search"
 )
 
@@ -96,13 +97,19 @@ func (se *StatusElement) applySubs(sub Core.SubstAndForm) {
 }
 
 func (se *StatusElement) sendChoice(choice Choice) {
-	Glob.PrintDebug("ASSISTED", fmt.Sprintf("Choice sent to state nº%d : %v", se.getId(), choice))
+	Glob.PrintDebug(
+		"ASSISTED",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Choice sent to state nº%d : %v", se.getId(), choice) }),
+	)
 
 	se.channel <- choice
 }
 
 func (se *StatusElement) receiveChoice() Choice {
 	choice := <-se.channel
-	Glob.PrintDebug("ASSISTED", fmt.Sprintf("Choice received from state nº%d : %v", se.getId(), choice))
+	Glob.PrintDebug(
+		"ASSISTED",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Choice received from state nº%d : %v", se.getId(), choice) }),
+	)
 	return choice
 }

--- a/src/Mods/dmt/axiom_registration.go
+++ b/src/Mods/dmt/axiom_registration.go
@@ -98,7 +98,10 @@ func printDebugRewriteRule(polarity bool, axiom, cons AST.Form) {
 	} else {
 		ax, co = AST.MakerNot(axiom).ToString(), cons.ToString()
 	}
-	Glob.PrintDebug("DMT", fmt.Sprintf("Rewrite rule: %s ---> %s\n", ax, co))
+	Glob.PrintDebug(
+		"DMT",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Rewrite rule: %s ---> %s\n", ax, co) }),
+	)
 }
 
 /**

--- a/src/Mods/equality/bse/constraints_list.go
+++ b/src/Mods/equality/bse/constraints_list.go
@@ -89,14 +89,31 @@ func makeEmptyConstaintsList() ConstraintList {
 
 /* Check if a constraint is consistant with LPO and constraint list */
 func (cl ConstraintList) isConsistantWithSubst(s Unif.Substitutions) bool {
-	Glob.PrintDebug("ICWS", fmt.Sprintf("Is consistant with the subst : %v", s.ToString()))
+	Glob.PrintDebug(
+		"ICWS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Is consistant with the subst : %v", s.ToString()) }),
+	)
 	for _, c_element := range cl {
 		c := c_element.copy()
-		Glob.PrintDebug("ICWS", fmt.Sprintf("Constraint : %v", c.toString()))
+		Glob.PrintDebug(
+			"ICWS",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Constraint : %v", c.toString()) }),
+		)
 		c.applySubstitution(s)
-		Glob.PrintDebug("ICWS", fmt.Sprintf("Constraint after apply subst : %v", c.toString()))
+		Glob.PrintDebug(
+			"ICWS",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Constraint after apply subst : %v", c.toString()) }),
+		)
 		respect_lpo, is_comparable := c.checkLPO()
-		Glob.PrintDebug("ICWS", fmt.Sprintf("Is comparable : %v - respect lpo : %v: ", is_comparable, respect_lpo))
+		Glob.PrintDebug(
+			"ICWS",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf(
+					"Is comparable : %v - respect lpo : %v: ",
+					is_comparable,
+					respect_lpo)
+			}),
+		)
 		if is_comparable && !respect_lpo {
 			return false
 		}
@@ -113,7 +130,7 @@ func (cl ConstraintList) checkConstraintList() bool {
 	map_constraintes := make(map[string][]Lib.List[AST.Term])
 
 	for _, c := range cl {
-		Glob.PrintDebug("CCL", fmt.Sprintf("Constraint : %v", c.toString()))
+		Glob.PrintDebug("CCL", Lib.MkLazy(func() string { return fmt.Sprintf("Constraint : %v", c.toString()) }))
 		switch c.getCType() {
 		case PREC:
 			if !appendToMapAndCheck(c.getTP().GetT1().ToString(), c.getTP().GetT2(), &map_constraintes, 1, 2) {

--- a/src/Mods/equality/bse/constraints_struct.go
+++ b/src/Mods/equality/bse/constraints_struct.go
@@ -40,6 +40,7 @@ import (
 	"fmt"
 
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Unif"
 )
 
@@ -92,15 +93,26 @@ func makeConstraintStruct(ac ConstraintList, s Unif.Substitutions, p ConstraintL
 
 /* Append relevant constraint if its consistant with cl and LPO */
 func (cs *ConstraintStruct) appendIfConsistant(c Constraint) bool {
-	// Glob.PrintDebug("AIC", fmt.Sprintf("CL : %v - c : %v", cl.ToString(), c.ToString()))
 	if !cs.getAllConstraints().contains(c) {
 		if is_consistant := cs.isConsistantWith(c); is_consistant {
-			Glob.PrintDebug("AIC", fmt.Sprintf("%v is consistant", c.toString()))
-			Glob.PrintDebug("AIC", fmt.Sprintf("CL at the end : %v", cs.toString()))
+			Glob.PrintDebug(
+				"AIC",
+				Lib.MkLazy(func() string { return fmt.Sprintf("%v is consistant", c.toString()) }),
+			)
+			Glob.PrintDebug(
+				"AIC",
+				Lib.MkLazy(func() string { return fmt.Sprintf("CL at the end : %v", cs.toString()) }),
+			)
 			return true
 		} else {
-			Glob.PrintDebug("AIC", fmt.Sprintf("%v is not consistant", c.toString()))
-			Glob.PrintDebug("AIC", fmt.Sprintf("CL at the end : %v", cs.toString()))
+			Glob.PrintDebug(
+				"AIC",
+				Lib.MkLazy(func() string { return fmt.Sprintf("%v is not consistant", c.toString()) }),
+			)
+			Glob.PrintDebug(
+				"AIC",
+				Lib.MkLazy(func() string { return fmt.Sprintf("CL at the end : %v", cs.toString()) }),
+			)
 			return false
 		}
 	}
@@ -109,14 +121,23 @@ func (cs *ConstraintStruct) appendIfConsistant(c Constraint) bool {
 
 /* Check if a constraint is consistant with LPO and constraint list + update cl */
 func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
-	Glob.PrintDebug("ICW", fmt.Sprintf("Constraint : %v", c.toString()))
+	Glob.PrintDebug(
+		"ICW",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Constraint : %v", c.toString()) }),
+	)
 	switch c.getCType() {
 	case PREC:
 		// Apply subst and check LPO
 		new_c := c.copy()
 		new_c.applySubstitution(cs.getSubst())
 		respect_lpo, is_comparable := new_c.checkLPO()
-		Glob.PrintDebug("ICW", fmt.Sprintf("Is_comparable : %v, respec_lpo : %v", is_comparable, respect_lpo))
+		Glob.PrintDebug(
+			"ICW",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf(
+					"Is_comparable : %v, respec_lpo : %v", is_comparable, respect_lpo)
+			}),
+		)
 		if is_comparable {
 			return respect_lpo
 		}
@@ -134,7 +155,10 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 	case EQ:
 		// Check if the EQ constraint is unifiable
 		subst := Unif.AddUnification(c.getTP().GetT1().Copy(), c.getTP().GetT2().Copy(), Unif.MakeEmptySubstitution())
-		Glob.PrintDebug("ICW", fmt.Sprintf("Candidate subst : %v", subst.ToString()))
+		Glob.PrintDebug(
+			"ICW",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Candidate subst : %v", subst.ToString()) }),
+		)
 		if subst.Equals(Unif.Failure()) {
 			return false
 		}
@@ -144,15 +168,28 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 
 		// Simplify it
 		// respect_lpo, is_comparable := c.checkLPO()
-		// Glob.PrintDebug("ICW", fmt.Sprintf("Is_comparable : %v, respec_lpo : %v", is_comparable, respect_lpo))
 		// if is_comparable {
 		//	return respect_lpo
 		// }
 
-		Glob.PrintDebug("ICW", fmt.Sprintf("Try to check compatibility : %v (%v and %v) and %v", subst.ToString(), c.getTP().GetT1().ToString(), c.getTP().GetT2().ToString(), cs.getSubst().ToString()))
+		Glob.PrintDebug(
+			"ICW",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf(
+					"Try to check compatibility : %v (%v and %v) and %v",
+					subst.ToString(),
+					c.getTP().GetT1().ToString(),
+					c.getTP().GetT2().ToString(),
+					cs.getSubst().ToString(),
+				)
+			}),
+		)
 		// Add it to subst and check unification consistency
 		subst_all := Unif.AddUnification(c.getTP().GetT1(), c.getTP().GetT2(), cs.getSubst())
-		Glob.PrintDebug("ICW", fmt.Sprintf("Subst all : %v", subst_all.ToString()))
+		Glob.PrintDebug(
+			"ICW",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Subst all : %v", subst_all.ToString()) }),
+		)
 		if subst_all.Equals(Unif.Failure()) {
 			return false
 		}
@@ -161,9 +198,9 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 		}
 
 		// Apply new global subst to prec
-		Glob.PrintDebug("ICW", "Check if consistant with the whole cl")
+		Glob.PrintDebug("ICW", Lib.MkLazy(func() string { return "Check if consistant with the whole cl" }))
 		if !cs.getPrec().isConsistantWithSubst(subst_all) {
-			Glob.PrintDebug("ICW", "Not consistant with the whole cl")
+			Glob.PrintDebug("ICW", Lib.MkLazy(func() string { return "Not consistant with the whole cl" }))
 			return false
 		}
 
@@ -173,7 +210,7 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 		return true
 
 	default:
-		Glob.PrintDebug("ICW", "Constraint type unknown")
+		Glob.PrintDebug("ICW", Lib.MkLazy(func() string { return "Constraint type unknown" }))
 		return false
 	}
 }

--- a/src/Mods/equality/bse/constraints_type.go
+++ b/src/Mods/equality/bse/constraints_type.go
@@ -99,9 +99,15 @@ func (c *Constraint) applySubstitution(s Unif.Substitutions) {
 
 /* return true if the constraint is not violated, false otherwise  + true is the contraint is comparable, false otherwise + update c into the useful part of the constraint */
 func (c *Constraint) checkLPO() (bool, bool) {
-	Glob.PrintDebug("CLPO", fmt.Sprintf("Type %v, cst : %v", c.getCType(), c.toString()))
+	Glob.PrintDebug(
+		"CLPO",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Type %v, cst : %v", c.getCType(), c.toString()) }),
+	)
 	cs := compareLPO(c.getTP().GetT1(), c.getTP().GetT2())
-	Glob.PrintDebug("CLPO", fmt.Sprintf("res : %v, is_comparable : %v", cs.order, cs.is_comparable))
+	Glob.PrintDebug(
+		"CLPO",
+		Lib.MkLazy(func() string { return fmt.Sprintf("res : %v, is_comparable : %v", cs.order, cs.is_comparable) }),
+	)
 
 	if cs.is_comparable {
 		switch c.getCType() {

--- a/src/Mods/equality/bse/equality.go
+++ b/src/Mods/equality/bse/equality.go
@@ -57,9 +57,9 @@ func SetTryEquality() {
 
 func TryEquality(atomics_for_dmt Core.FormAndTermsList, st Search.State, new_atomics Core.FormAndTermsList, father_id uint64, cha Search.Communication, node_id int, original_node_id int) bool {
 	if !Glob.GetDMTBeforeEq() || len(atomics_for_dmt) == 0 || len(st.GetLF()) == 0 {
-		Glob.PrintDebug("PS", "Try apply EQ !")
+		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Try apply EQ !" }))
 		if len(new_atomics) > 0 || len(st.GetLF()) == 0 {
-			Glob.PrintDebug("PS", "EQ is applicable !")
+			Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "EQ is applicable !" }))
 			atomics_plus_dmt := append(st.GetAtomic(), atomics_for_dmt...)
 			res_eq, subst_eq := EqualityReasoning(st.GetEqStruct(), st.GetTreePos(), st.GetTreeNeg(), atomics_plus_dmt.ExtractForms(), original_node_id)
 			if res_eq {
@@ -89,7 +89,7 @@ func TryEquality(atomics_for_dmt Core.FormAndTermsList, st Search.State, new_ato
 * returns a bool for success and the corresponding substitution
 **/
 func EqualityReasoning(eqStruct eqStruct.EqualityStruct, tree_pos, tree_neg Unif.DataStructure, atomic *AST.FormList, originalNodeId int) (bool, []Unif.Substitutions) {
-	Glob.PrintDebug("ER", "ER call")
+	Glob.PrintDebug("ER", Lib.MkLazy(func() string { return "ER call" }))
 	problem, equalities := buildEqualityProblemMultiList(atomic, tree_pos, tree_neg)
 	if equalities {
 		return RunEqualityReasoning(eqStruct, problem)

--- a/src/Mods/equality/bse/equality_problem_list.go
+++ b/src/Mods/equality/bse/equality_problem_list.go
@@ -235,7 +235,10 @@ func buildEqualityProblemMultiListFromFormList(fl *AST.FormList, tn Unif.DataStr
 	res := makeEmptyEqualityProblemMultiList()
 	for _, p := range fl.Slice() {
 		if pt, ok := p.(AST.Pred); ok {
-			Glob.PrintDebug("BEPMLFFL", fmt.Sprintf("Pred found : %v", p.ToString()))
+			Glob.PrintDebug(
+				"BEPMLFFL",
+				Lib.MkLazy(func() string { return fmt.Sprintf("Pred found : %v", p.ToString()) }),
+			)
 			if !pt.GetID().Equals(AST.Id_eq) {
 				res = append(res, buildEqualityProblemMultiListFromPredList(pt, tn, eq.copy())...)
 			}
@@ -255,9 +258,15 @@ func buildEqualityProblemMultiList(fl *AST.FormList, tp, tn Unif.DataStructure) 
 		return res, false
 	}
 	res = append(res, buildEqualityProblemMultiListFromNEQ(retrieveInequalities(tn.Copy()), eq.copy())...)
-	Glob.PrintDebug("BEPML", fmt.Sprintf("Res after FromNEQ : %v", res.ToString()))
+	Glob.PrintDebug(
+		"BEPML",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Res after FromNEQ : %v", res.ToString()) }),
+	)
 	res = append(res, buildEqualityProblemMultiListFromFormList(fl.Copy(), tn.Copy(), eq.copy())...)
-	Glob.PrintDebug("BEPML", fmt.Sprintf("Res after FromForm : %v", res.ToString()))
+	Glob.PrintDebug(
+		"BEPML",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Res after FromForm : %v", res.ToString()) }),
+	)
 
 	if len(res) == 0 {
 		return res, false

--- a/src/Mods/equality/bse/equality_rules_apply.go
+++ b/src/Mods/equality/bse/equality_rules_apply.go
@@ -41,63 +41,94 @@ import (
 
 	"github.com/GoelandProver/Goeland/AST"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Mods/equality/eqStruct"
 )
 
 /* apply a rule */
 func applyRule(rs ruleStruct, ep EqualityProblem, parent chan answerEP, father_id uint64) {
-	Glob.PrintDebug("EQ-AR", fmt.Sprintf("Child of %v", father_id))
-	Glob.PrintDebug("EQ-AR", fmt.Sprintf("EQ before applying rule %v", ep.ToString()))
-	Glob.PrintDebug("EQ-AR", fmt.Sprintf("Apply rule %v", rs.toString()))
+	Glob.PrintDebug("EQ-AR", Lib.MkLazy(func() string { return fmt.Sprintf("Child of %v", father_id) }))
+	Glob.PrintDebug(
+		"EQ-AR",
+		Lib.MkLazy(func() string { return fmt.Sprintf("EQ before applying rule %v", ep.ToString()) }),
+	)
+	Glob.PrintDebug(
+		"EQ-AR",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Apply rule %v", rs.toString()) }),
+	)
 	switch rs.getRule() {
 	case LEFT:
 		applyLeftRule(rs, ep, parent, father_id)
 	case RIGHT:
 		applyRightRule(rs, ep, parent, father_id)
 	default:
-		Glob.PrintDebug("AR", "[EQ] Rule type unknown")
+		Glob.PrintDebug(
+			"AR",
+			Lib.MkLazy(func() string { return "[EQ] Rule type unknown" }),
+		)
 	}
 }
 
 /* Apply left rigid basic superposition rule */
 func applyLeftRule(rs ruleStruct, ep EqualityProblem, father_chan chan answerEP, father_id uint64) {
-	Glob.PrintDebug("ALR", "Apply left rule")
+	Glob.PrintDebug(
+		"ALR",
+		Lib.MkLazy(func() string { return "Apply left rule" }),
+	)
 	is_consistant_with_lpo, new_term, new_cl := applyEQRule(rs.getL(), rs.getR(), rs.getLPrime(), rs.getS(), rs.getT(), ep.getC())
 
 	if is_consistant_with_lpo {
-		Glob.PrintDebug("ALR", fmt.Sprintf("New term : %v", new_term.ToString()))
+		Glob.PrintDebug(
+			"ALR",
+			Lib.MkLazy(func() string { return fmt.Sprintf("New term : %v", new_term.ToString()) }),
+		)
 		new_eq_list := ep.GetE()
 		if rs.getIsSModified() {
 			new_eq_list[rs.getIndexEQList()] = eqStruct.MakeTermPair(new_term.Copy(), rs.getT())
 		} else {
 			new_eq_list[rs.getIndexEQList()] = eqStruct.MakeTermPair(rs.getS(), new_term.Copy())
 		}
-		Glob.PrintDebug("ALR", fmt.Sprintf("New EQ list : %v", new_eq_list.ToString()))
+		Glob.PrintDebug(
+			"ALR",
+			Lib.MkLazy(func() string { return fmt.Sprintf("New EQ list : %v", new_eq_list.ToString()) }),
+		)
 		tryEqualityReasoningProblem(makeEqualityProblem(new_eq_list, ep.GetS(), ep.GetT(), new_cl), father_chan, rs.getIndexEQList(), LEFT, father_id)
 	} else {
-		Glob.PrintDebug("ALR", "Not consistant with LPO, send nil")
+		Glob.PrintDebug(
+			"ALR",
+			Lib.MkLazy(func() string { return "Not consistant with LPO, send nil" }),
+		)
 		father_chan <- makeEmptyAnswerEP()
-		Glob.PrintDebug("ALR", "Die")
+		Glob.PrintDebug("ALR", Lib.MkLazy(func() string { return "Die" }))
 	}
 }
 
 /* Apply right rigid basic superposition rule */
 func applyRightRule(rs ruleStruct, ep EqualityProblem, father_chan chan answerEP, father_id uint64) {
-	Glob.PrintDebug("ARR", "Apply right rule")
+	Glob.PrintDebug(
+		"ARR",
+		Lib.MkLazy(func() string { return "Apply right rule" }),
+	)
 
 	is_consistant_with_lpo, new_term, new_cl := applyEQRule(rs.getL(), rs.getR(), rs.getLPrime(), rs.getS(), rs.getT(), ep.getC())
 
 	if is_consistant_with_lpo {
-		Glob.PrintDebug("ARR", fmt.Sprintf("New term : %v", new_term.ToString()))
+		Glob.PrintDebug(
+			"ARR",
+			Lib.MkLazy(func() string { return fmt.Sprintf("New term : %v", new_term.ToString()) }),
+		)
 		if rs.getIsSModified() {
 			tryEqualityReasoningProblem(makeEqualityProblem(ep.copy().GetE(), new_term.Copy(), rs.getT(), new_cl), father_chan, rs.getIndexEQList(), RIGHT, father_id)
 		} else {
 			tryEqualityReasoningProblem(makeEqualityProblem(ep.copy().GetE(), rs.getS(), new_term.Copy(), new_cl), father_chan, rs.getIndexEQList(), RIGHT, father_id)
 		}
 	} else {
-		Glob.PrintDebug("ARR", "Not consistant with LPO, send nil")
+		Glob.PrintDebug(
+			"ARR",
+			Lib.MkLazy(func() string { return "Not consistant with LPO, send nil" }),
+		)
 		father_chan <- makeEmptyAnswerEP()
-		Glob.PrintDebug("ARR", "Die")
+		Glob.PrintDebug("ARR", Lib.MkLazy(func() string { return "Die" }))
 	}
 }
 
@@ -109,10 +140,22 @@ func applyRightRule(rs ruleStruct, ep EqualityProblem, father_chan chan answerEP
 * sub_term_of s is a subterm of s unifible with l
 **/
 func applyEQRule(l, r, sub_term_of_s, s, t AST.Term, cs ConstraintStruct) (bool, AST.Term, ConstraintStruct) {
-	Glob.PrintDebug("AEQR", "Apply eq rule")
-	Glob.PrintDebug("AEQR", fmt.Sprintf("Replace %v by %v in %v", sub_term_of_s.ToString(), r.ToString(), s.ToString()))
+	Glob.PrintDebug(
+		"AEQR",
+		Lib.MkLazy(func() string { return "Apply eq rule" }),
+	)
+	Glob.PrintDebug(
+		"AEQR",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Replace %v by %v in %v", sub_term_of_s.ToString(), r.ToString(), s.ToString())
+		}),
+	)
 	new_s := s.Copy().ReplaceSubTermBy(sub_term_of_s, r)
-	Glob.PrintDebug("AEQR", fmt.Sprintf("s = %v, new_s = %v", s.ToString(), new_s.ToString()))
+	Glob.PrintDebug(
+		"AEQR",
+		Lib.MkLazy(func() string { return fmt.Sprintf("s = %v, new_s = %v", s.ToString(), new_s.ToString()) }),
+	)
 	constraints_list := cs.copy()
 
 	if !constraints_list.appendIfConsistant(MakeConstraint(PREC, eqStruct.MakeTermPair(r, l))) {

--- a/src/Mods/equality/bse/equality_rules_reasoning.go
+++ b/src/Mods/equality/bse/equality_rules_reasoning.go
@@ -40,6 +40,7 @@ import (
 	"fmt"
 
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Mods/equality/eqStruct"
 	"github.com/GoelandProver/Goeland/Unif"
 )
@@ -65,16 +66,33 @@ func (bes *BasicEqualityStruct) AddGoal(goal []eqStruct.TermPair) {
 }
 
 func (bes *BasicEqualityStruct) Solve() (subs []Unif.Substitutions, success bool) {
-	Glob.PrintDebug("ERML", fmt.Sprintf("Start of Equality reasoning multilist : %v", bes.goals.Len()))
+	Glob.PrintDebug(
+		"ERML",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Start of Equality reasoning multilist : %v",
+				bes.goals.Len())
+		}),
+	)
 	substs_res := []Unif.Substitutions{}
 	found := false
 
 	for _, goal := range bes.goals.Slice() {
 		epl := makeEqualityProblemList(bes.assumptions.Slice(), goal.Slice())
 
-		Glob.PrintDebug("ERML", fmt.Sprintf("iteration on EPL : %v", epl.ToString()))
+		Glob.PrintDebug(
+			"ERML",
+			Lib.MkLazy(func() string { return fmt.Sprintf("iteration on EPL : %v", epl.ToString()) }),
+		)
 		if has_solution, subst_res_tmp := equalityReasoningList(epl); has_solution {
-			Glob.PrintDebug("ERML", fmt.Sprintf("Solution found for one EPL : %v !", Unif.SubstListToString(subst_res_tmp)))
+			Glob.PrintDebug(
+				"ERML",
+				Lib.MkLazy(func() string {
+					return fmt.Sprintf(
+						"Solution found for one EPL : %v !",
+						Unif.SubstListToString(subst_res_tmp))
+				}),
+			)
 			found = true
 			for subst_res_tmp_element := range subst_res_tmp {
 				substs_res = Unif.AppendIfNotContainsSubst(substs_res, subst_res_tmp[subst_res_tmp_element])
@@ -82,7 +100,14 @@ func (bes *BasicEqualityStruct) Solve() (subs []Unif.Substitutions, success bool
 		}
 	}
 
-	Glob.PrintDebug("ERML", fmt.Sprintf("Final subst after ER : %v", Unif.SubstListToString(substs_res)))
+	Glob.PrintDebug(
+		"ERML",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Final subst after ER : %v",
+				Unif.SubstListToString(substs_res))
+		}),
+	)
 	return substs_res, found
 }
 
@@ -126,15 +151,28 @@ func RunEqualityReasoning(es eqStruct.EqualityStruct, epml EqualityProblemMultiL
 * Result : true if all of the problem in the list agrees on at least one substitution, and the corresponding substitutions
 **/
 func equalityReasoningList(epl EqualityProblemList) (bool, []Unif.Substitutions) {
-	Glob.PrintDebug("ERML", fmt.Sprintf("Start of Equality reasoning list : %v", epl.ToString()))
+	Glob.PrintDebug(
+		"ERML",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Start of Equality reasoning list : %v", epl.ToString()) }),
+	)
 
 	substs_res := []Unif.Substitutions{}
 
 	for _, ep := range epl {
-		Glob.PrintDebug("ERL", fmt.Sprintf("Iteration on EP : %v", ep.ToString()))
+		Glob.PrintDebug(
+			"ERL",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Iteration on EP : %v", ep.ToString()) }),
+		)
 		// Each step manage one problem with n subtitutions
 		if has_solution, subst_res_tmp := manageEqualityReasoningProblem(ep.copy(), substs_res); has_solution {
-			Glob.PrintDebug("ERL", fmt.Sprintf("Solution found for on EP : %v !", Unif.SubstListToString(subst_res_tmp)))
+			Glob.PrintDebug(
+				"ERL",
+				Lib.MkLazy(func() string {
+					return fmt.Sprintf(
+						"Solution found for on EP : %v !",
+						Unif.SubstListToString(subst_res_tmp))
+				}),
+			)
 			substs_res = Unif.CopySubstList(subst_res_tmp)
 		} else {
 			return false, []Unif.Substitutions{Unif.Failure()}
@@ -145,7 +183,10 @@ func equalityReasoningList(epl EqualityProblemList) (bool, []Unif.Substitutions)
 
 /* return true if at least on subst on the subst list returns result, and the corresponding substitution list */
 func manageEqualityReasoningProblem(ep EqualityProblem, sl []Unif.Substitutions) (bool, []Unif.Substitutions) {
-	Glob.PrintDebug("ERPWAS", "Start on equality reasoning  problem with apply subst")
+	Glob.PrintDebug(
+		"ERPWAS",
+		Lib.MkLazy(func() string { return "Start on equality reasoning  problem with apply subst" }),
+	)
 	if len(sl) == 0 {
 		subst := launchEqualityReasoningProblem(ep)
 		return len(subst) > 0, subst

--- a/src/Mods/equality/bse/equality_rules_try_apply.go
+++ b/src/Mods/equality/bse/equality_rules_try_apply.go
@@ -48,7 +48,10 @@ import (
 
 /* Try left rule */
 func tryApplyLeftRules(ep EqualityProblem, index_begin int) ruleStructList {
-	Glob.PrintDebug("TALR", "-- Try apply left rule")
+	Glob.PrintDebug(
+		"TALR",
+		Lib.MkLazy(func() string { return "-- Try apply left rule" }),
+	)
 	res := ruleStructList{}
 	i := index_begin
 	for i < len(ep.GetE()) {
@@ -57,17 +60,26 @@ func tryApplyLeftRules(ep EqualityProblem, index_begin int) ruleStructList {
 		res = append(res, tryApplyRuleAux(eq_pair.GetT2(), eq_pair.GetT1(), ep.copy(), LEFT, false, i)...)
 		i++
 	}
-	Glob.PrintDebug("TALR", "-- End of Try apply left rule")
+	Glob.PrintDebug(
+		"TALR",
+		Lib.MkLazy(func() string { return "-- End of Try apply left rule" }),
+	)
 	return res
 }
 
 /* Try right rule */
 func tryApplyRightRules(ep EqualityProblem) ruleStructList {
-	Glob.PrintDebug("TARR", "-- Try apply right rule")
+	Glob.PrintDebug(
+		"TARR",
+		Lib.MkLazy(func() string { return "-- Try apply right rule" }),
+	)
 	res := ruleStructList{}
 	res = append(res, tryApplyRuleAux(ep.GetS(), ep.GetT(), ep.copy(), RIGHT, true, -1)...)
 	res = append(res, tryApplyRuleAux(ep.GetT(), ep.GetS(), ep.copy(), RIGHT, false, -1)...)
-	Glob.PrintDebug("TARR", "-- End of Try apply right rule")
+	Glob.PrintDebug(
+		"TARR",
+		Lib.MkLazy(func() string { return "-- End of Try apply right rule" }),
+	)
 	return res
 }
 
@@ -85,21 +97,41 @@ func tryApplyRuleAux(t1, t2 AST.Term, ep EqualityProblem, ruleType int, is_s_mod
 
 // Take s, t and return a rule
 func tryApplyRuleCompute(s, t AST.Term, ep EqualityProblem, type_rule int) ruleStructList {
-	Glob.PrintDebug("TARA", "===============================================")
-	Glob.PrintDebug("TARA", fmt.Sprintf("Try apply rule aux on : %v and %v", s.ToString(), t.ToString()))
+	Glob.PrintDebug(
+		"TARA",
+		Lib.MkLazy(func() string { return "===============================================" }),
+	)
+	Glob.PrintDebug(
+		"TARA",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Try apply rule aux on : %v and %v",
+				s.ToString(),
+				t.ToString(),
+			)
+		}),
+	)
 
 	// Retrieve the list of substerm of s
 	subterms_of_s := s.GetSubTerms()
-	Glob.PrintDebug("TARA", fmt.Sprintf(
-		"len subterms found : %v - %v",
-		subterms_of_s.Len(),
-		subterms_of_s.ToString(AST.Term.ToString, ",", "[]"),
-	))
-	Glob.PrintDebug("TARA", fmt.Sprintf("EP eq list : %v", ep.GetE().ToString()))
+	Glob.PrintDebug("TARA", Lib.MkLazy(func() string {
+		return fmt.Sprintf(
+			"len subterms found : %v - %v",
+			subterms_of_s.Len(),
+			subterms_of_s.ToString(AST.Term.ToString, ",", "[]"),
+		)
+	}))
+	Glob.PrintDebug(
+		"TARA",
+		Lib.MkLazy(func() string { return fmt.Sprintf("EP eq list : %v", ep.GetE().ToString()) }),
+	)
 
 	// for each l' substerm of s, return a list (l', l) unifiable
 	list_l_prime_l := searchUnifBewteenListAndEq(subterms_of_s, ep.getETree())
-	Glob.PrintDebug("TARA", fmt.Sprintf("len unifiable subterms found : %v", len(list_l_prime_l)))
+	Glob.PrintDebug(
+		"TARA",
+		Lib.MkLazy(func() string { return fmt.Sprintf("len unifiable subterms found : %v", len(list_l_prime_l)) }),
+	)
 
 	// Now, for each (l', l),  retrieve the r corresponding to the l
 	return connectLAndR(list_l_prime_l, ep, s, t, type_rule)
@@ -110,10 +142,28 @@ func connectLAndR(list_l_prime_l []eqStruct.TermPair, ep EqualityProblem, s AST.
 	res := ruleStructList{}
 
 	for _, l_prime_l_pair := range list_l_prime_l {
-		Glob.PrintDebug("TARA", fmt.Sprintf("Subterms unifiable found : %v", l_prime_l_pair.ToString()))
+		Glob.PrintDebug(
+			"TARA",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf(
+					"Subterms unifiable found : %v",
+					l_prime_l_pair.ToString())
+			}),
+		)
 
 		for _, r := range ep.getEMap()[l_prime_l_pair.GetT2().ToString()].GetSlice() {
-			Glob.PrintDebug("TARA", fmt.Sprintf("On veut susbstituer %v (unifiable avec %v) par %v dans %v = %v", l_prime_l_pair.GetT1().ToString(), l_prime_l_pair.GetT2().ToString(), r.ToString(), s.ToString(), t.ToString()))
+			Glob.PrintDebug(
+				"TARA",
+				Lib.MkLazy(func() string {
+					return fmt.Sprintf(
+						"We wish to subst %v (unifiable with %v) by %v in %v = %v",
+						l_prime_l_pair.GetT1().ToString(),
+						l_prime_l_pair.GetT2().ToString(),
+						r.ToString(),
+						s.ToString(),
+						t.ToString())
+				}),
+			)
 
 			// create pair an check equality
 			s_t := eqStruct.MakeTermPair(s, t)
@@ -121,10 +171,16 @@ func connectLAndR(list_l_prime_l []eqStruct.TermPair, ep EqualityProblem, s AST.
 
 			// if s = t is not l = r OR, if they are, the rule's type is right, so it's ok
 			if !s_t.EqualsModulo(l_r) || type_rule == RIGHT {
-				Glob.PrintDebug("TARA", "Try apply rule ok !")
+				Glob.PrintDebug(
+					"TARA",
+					Lib.MkLazy(func() string { return "Try apply rule ok !" }),
+				)
 				res = append(res, makeRuleStruct(type_rule, l_prime_l_pair.GetT2(), r.Copy(), l_prime_l_pair.GetT1(), s.Copy(), t.Copy()))
 			} else {
-				Glob.PrintDebug("TARA", "Don't apply an equality on itself")
+				Glob.PrintDebug(
+					"TARA",
+					Lib.MkLazy(func() string { return "Don't apply an equality on itself" }),
+				)
 			}
 		}
 	}
@@ -133,28 +189,48 @@ func connectLAndR(list_l_prime_l []eqStruct.TermPair, ep EqualityProblem, s AST.
 
 /* return all the pair (l, l') unifiable */
 func searchUnifBewteenListAndEq(tl Lib.List[AST.Term], tree Unif.DataStructure) []eqStruct.TermPair {
-	Glob.PrintDebug("SUBLE", fmt.Sprintf(
-		"Searching unfication between %v and the eq tree",
-		tl.ToString(AST.Term.ToString, ",", "[]"),
-	))
+	Glob.PrintDebug("SUBLE", Lib.MkLazy(func() string {
+		return fmt.Sprintf(
+			"Searching unfication between %v and the eq tree",
+			tl.ToString(AST.Term.ToString, ",", "[]"),
+		)
+	}))
 	term_pair_list := []eqStruct.TermPair{}
 	for _, t_prime := range tl.GetSlice() {
 		// If the subterm is not a variable
-		Glob.PrintDebug("SUBLE", "------------------------------------------")
-		Glob.PrintDebug("SUBLE", fmt.Sprintf("Current subterm : %v", t_prime.ToString()))
+		Glob.PrintDebug(
+			"SUBLE",
+			Lib.MkLazy(func() string { return "------------------------------------------" }),
+		)
+		Glob.PrintDebug(
+			"SUBLE",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Current subterm : %v", t_prime.ToString()) }),
+		)
 		if !t_prime.IsMeta() {
 			res, tl := checkUnifInTree(t_prime, tree)
 			if res {
-				Glob.PrintDebug("SUBLE", "Unification found !")
+				Glob.PrintDebug(
+					"SUBLE",
+					Lib.MkLazy(func() string { return "Unification found !" }),
+				)
 				for _, t := range tl.GetSlice() {
-					Glob.PrintDebug("SUBLE", fmt.Sprintf("Unif found with : %v", t.ToString()))
+					Glob.PrintDebug(
+						"SUBLE",
+						Lib.MkLazy(func() string { return fmt.Sprintf("Unif found with : %v", t.ToString()) }),
+					)
 					term_pair_list = append(term_pair_list, eqStruct.MakeTermPair(t_prime, t))
 				}
 			} else {
-				Glob.PrintDebug("SUBLE", "Unification not found !")
+				Glob.PrintDebug(
+					"SUBLE",
+					Lib.MkLazy(func() string { return "Unification not found !" }),
+				)
 			}
 		} else {
-			Glob.PrintDebug("SUBLE", fmt.Sprintf("%v is a meta !", t_prime.ToString()))
+			Glob.PrintDebug(
+				"SUBLE",
+				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a meta !", t_prime.ToString()) }),
+			)
 		}
 	}
 	return term_pair_list
@@ -170,7 +246,13 @@ func checkUnifInTree(t AST.Term, tree Unif.DataStructure) (bool, Lib.List[AST.Te
 	}
 
 	for _, subst := range ms {
-		Glob.PrintDebug("CUIT", fmt.Sprintf("Unif found with %v :%v", subst.GetForm().ToString(), subst.GetSubst().ToString()))
+		Glob.PrintDebug(
+			"CUIT",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf("Unif found with %v :%v",
+					subst.GetForm().ToString(), subst.GetSubst().ToString())
+			}),
+		)
 		result_list.Append(subst.GetForm().(Unif.TermForm).GetTerm())
 	}
 

--- a/src/Mods/equality/bse/equality_rules_utils.go
+++ b/src/Mods/equality/bse/equality_rules_utils.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/GoelandProver/Goeland/AST"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Unif"
 )
 
@@ -75,22 +76,40 @@ func tryUnifySAndT(s, t AST.Term) (bool, Unif.Substitutions) {
 /* check unfiication */
 func checkUnif(ep EqualityProblem) (found bool, substs_res []Unif.Substitutions) {
 	if ok, subst_found := tryUnifySAndT(ep.GetS(), ep.GetT()); ok {
-		Glob.PrintDebug("ERP", "Unif found !")
+		Glob.PrintDebug("ERP", Lib.MkLazy(func() string { return "Unif found !" }))
 		new_subst := Unif.AddUnification(ep.GetS(), ep.GetT(), ep.getC().getSubst())
 		if !new_subst.Equals(Unif.Failure()) {
 			is_consistant := ep.c.getPrec().isConsistantWithSubst(new_subst)
 			if is_consistant {
-				Glob.PrintDebug("ERP", fmt.Sprintf("Unif found and consistant : %v", new_subst.ToString()))
+				Glob.PrintDebug(
+					"ERP",
+					Lib.MkLazy(func() string {
+						return fmt.Sprintf(
+							"Unif found and consistant : %v", new_subst.ToString())
+					}),
+				)
 				found = true
 				substs_res = append(substs_res, new_subst)
 			} else {
-				Glob.PrintDebug("ERP", fmt.Sprintf("Unif found but not consistant : %v", subst_found.ToString()))
+				Glob.PrintDebug(
+					"ERP",
+					Lib.MkLazy(func() string {
+						return fmt.Sprintf(
+							"Unif found but not consistant : %v", subst_found.ToString())
+					}),
+				)
 			}
 		} else {
-			Glob.PrintDebug("ERP", fmt.Sprintf("Unif found but not consistant with other unifications : %v", subst_found.ToString()))
+			Glob.PrintDebug(
+				"ERP",
+				Lib.MkLazy(func() string {
+					return fmt.Sprintf(
+						"Unif found but not consistant with other unifications : %v", subst_found.ToString())
+				}),
+			)
 		}
 	} else {
-		Glob.PrintDebug("ERP", "Unification not found")
+		Glob.PrintDebug("ERP", Lib.MkLazy(func() string { return "Unification not found" }))
 	}
 	return found, substs_res
 }

--- a/src/Mods/equality/bse/equality_test.go
+++ b/src/Mods/equality/bse/equality_test.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/GoelandProver/Goeland/Core"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Typing"
 	"github.com/GoelandProver/Goeland/Unif"
 	"github.com/GoelandProver/Goeland/equality/eqStruct"
@@ -285,8 +286,14 @@ func TestAS(t *testing.T) {
 	s.Set(y, a)
 	new_ep := ep.applySubstitution(s)
 
-	Glob.PrintDebug("TEST_AS", fmt.Sprintf("Current EP : %v", new_ep.ToString()))
-	Glob.PrintDebug("TEST_AS", fmt.Sprintf("Expected : %v", expected_ep.ToString()))
+	Glob.PrintDebug(
+		"TEST_AS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Current EP : %v", new_ep.ToString()) }),
+	)
+	Glob.PrintDebug(
+		"TEST_AS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Expected : %v", expected_ep.ToString()) }),
+	)
 }
 
 /*** Test constraints ***/

--- a/src/Mods/equality/bse/lpo.go
+++ b/src/Mods/equality/bse/lpo.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/GoelandProver/Goeland/AST"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 )
 
 type compareStruct struct {
@@ -65,31 +66,52 @@ func makeEmptyCompareStruct() compareStruct {
 *	two terms : the new terms for the constraint (if not comparable)
 **/
 func compareLPO(s, t AST.Term) compareStruct {
-	Glob.PrintDebug("CPR", fmt.Sprintf("Compare %v and %v", s.ToString(), t.ToString()))
+	Glob.PrintDebug(
+		"CPR",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Compare %v and %v", s.ToString(), t.ToString()) }),
+	)
 	switch s_type := s.(type) {
 	case AST.Fun:
-		Glob.PrintDebug("CPR", fmt.Sprintf("%v is a function", s.ToString()))
+		Glob.PrintDebug(
+			"CPR",
+			Lib.MkLazy(func() string { return fmt.Sprintf("%v is a function", s.ToString()) }),
+		)
 		switch t_type := t.(type) {
 		case AST.Fun:
-			Glob.PrintDebug("CPR", fmt.Sprintf("%v is a function", t.ToString()))
+			Glob.PrintDebug(
+				"CPR",
+				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a function", t.ToString()) }),
+			)
 			// function and function
 			return compareFunFun(s_type, t_type)
 		case AST.Meta:
-			Glob.PrintDebug("CPR", fmt.Sprintf("%v is a Meta", t.ToString()))
+			Glob.PrintDebug(
+				"CPR",
+				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a Meta", t.ToString()) }),
+			)
 			// function & meta : Occurences inside : f(x) < x, f(y) < x
 			return compareMetaFun(t_type, s_type, -1)
 		default:
 			Glob.PrintError("CPR", "Type of t unknown")
 		}
 	case AST.Meta:
-		Glob.PrintDebug("CPR", fmt.Sprintf("%v is a Meta", s.ToString()))
+		Glob.PrintDebug(
+			"CPR",
+			Lib.MkLazy(func() string { return fmt.Sprintf("%v is a Meta", s.ToString()) }),
+		)
 		switch t_type := t.(type) {
 		case AST.Fun:
-			Glob.PrintDebug("CPR", fmt.Sprintf("%v is a function", t.ToString()))
+			Glob.PrintDebug(
+				"CPR",
+				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a function", t.ToString()) }),
+			)
 			// meta & function : Occurences inside : x < f(x), x < f(y)
 			return compareMetaFun(s_type, t_type, 1)
 		case AST.Meta:
-			Glob.PrintDebug("CPR", fmt.Sprintf("%v is a Meta", t.ToString()))
+			Glob.PrintDebug(
+				"CPR",
+				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a Meta", t.ToString()) }),
+			)
 			// Meta and meta
 			return compareMetaMeta(s_type, t_type)
 		default:
@@ -108,14 +130,23 @@ func compareLPO(s, t AST.Term) compareStruct {
 * For example, x < f(x) is ok but f(x) < x isn't
 **/
 func compareMetaFun(m AST.Meta, f AST.Fun, return_code int) compareStruct {
-	Glob.PrintDebug("CMF", "Compare Meta Fun")
+	Glob.PrintDebug(
+		"CMF",
+		Lib.MkLazy(func() string { return "Compare Meta Fun" }),
+	)
 	// Check argument inside f
 	if found, res := compareMetaFunInside(m, f, return_code); found {
-		Glob.PrintDebug("CMF", fmt.Sprintf("Found after compare inside : %v", res))
+		Glob.PrintDebug(
+			"CMF",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Found after compare inside : %v", res) }),
+		)
 		return res
 	}
 
-	Glob.PrintDebug("CMF", fmt.Sprintf("Not found and return_code is %v", return_code))
+	Glob.PrintDebug(
+		"CMF",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Not found and return_code is %v", return_code) }),
+	)
 	// f has no args or all respect LPO
 	if return_code == 1 {
 		return makeCompareStruct(0, false, m, f)
@@ -125,7 +156,10 @@ func compareMetaFun(m AST.Meta, f AST.Fun, return_code int) compareStruct {
 }
 
 func compareMetaFunInside(m AST.Meta, f AST.Fun, return_code int) (bool, compareStruct) {
-	Glob.PrintDebug("CMFI", "Compare Meta Fun Inside")
+	Glob.PrintDebug(
+		"CMFI",
+		Lib.MkLazy(func() string { return "Compare Meta Fun Inside" }),
+	)
 	i := 0
 	// Check arguments to find occur-check eventually
 	for i < f.GetArgs().Len() {
@@ -167,7 +201,10 @@ func compareMetaMeta(m1, m2 AST.Meta) compareStruct {
 
 /* Compare two functions */
 func compareFunFun(s, t AST.Fun) compareStruct {
-	Glob.PrintDebug("CFF", "Compare Fun Fun")
+	Glob.PrintDebug(
+		"CFF",
+		Lib.MkLazy(func() string { return "Compare Fun Fun" }),
+	)
 
 	switch s.GetID().CompareWith(t.GetID()) {
 	case -1:
@@ -211,7 +248,10 @@ func caseFLessG(s, t AST.Fun) (bool, compareStruct) {
 
 /* Case f == g */
 func caseFEqualsG(s, t AST.Fun) (bool, compareStruct) {
-	Glob.PrintDebug("F=G", "Case F = G")
+	Glob.PrintDebug(
+		"F=G",
+		Lib.MkLazy(func() string { return "Case F = G" }),
+	)
 	if s.GetArgs().Len() != t.GetArgs().Len() {
 		Glob.PrintError("F=G", fmt.Sprintf("Error : %v and %v don't have the same number of arguments", s.GetID().ToString(), t.GetID().ToString()))
 		return true, makeCompareStruct(0, false, nil, nil)
@@ -227,7 +267,16 @@ func caseFEqualsG(s, t AST.Fun) (bool, compareStruct) {
 
 		// Bug here : les autres arguments !
 		if !cs.is_comparable {
-			Glob.PrintDebug("F=G", fmt.Sprintf("Not comparable, return : %v and %v", cs.new_t1.ToString(), cs.new_t2.ToString()))
+			Glob.PrintDebug(
+				"F=G",
+				Lib.MkLazy(func() string {
+					return fmt.Sprintf(
+						"Not comparable, return : %v and %v",
+						cs.new_t1.ToString(),
+						cs.new_t2.ToString(),
+					)
+				}),
+			)
 			return true, makeCompareStruct(0, false, cs.new_t1, cs.new_t2)
 		}
 		if cs.order != 0 {

--- a/src/Search/child_management.go
+++ b/src/Search/child_management.go
@@ -78,24 +78,52 @@ func MakeWcdArgs(
 }
 
 func (args wcdArgs) printDebugMessages() {
-	Glob.PrintDebug("WC", "Waiting children")
-	Glob.PrintDebug("WC", fmt.Sprintf("Id : %v, original node id :%v", args.nodeId, args.originalNodeId))
-	Glob.PrintDebug("WC", fmt.Sprintf("Child order : %v", args.childOrdering))
-	Glob.PrintDebug("WC", fmt.Sprintf("Children : %v, BT_subst : %v, BT_formulas : %v, bt_bool : %v, Given_subst : %v, applied subst : %v, subst_found : %v", len(args.children), len(args.substsBT), len(args.formsBT), args.st.GetBTOnFormulas(), Core.SubstAndFormListToString(args.givenSubsts), args.st.GetAppliedSubst().ToString(), Core.SubstAndFormListToString(args.st.GetSubstsFound())))
-	Glob.PrintDebug("WC", fmt.Sprintf(
-		"MM : %v",
-		Lib.ListToString(args.st.GetMM().Elements(), ",", "[]"),
-	))
-	Glob.PrintDebug("WC", fmt.Sprintf(
-		"MC : %v",
-		Lib.ListToString(args.st.GetMC().Elements(), ",", "[]"),
-	))
+	Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Waiting children" }))
+	Glob.PrintDebug(
+		"WC",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Id : %v, original node id :%v",
+				args.nodeId,
+				args.originalNodeId)
+		}),
+	)
+	Glob.PrintDebug(
+		"WC",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Child order : %v", args.childOrdering) }),
+	)
+	Glob.PrintDebug(
+		"WC",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Children : %v, BT_subst : %v, BT_formulas : %v, bt_bool : %v, Given_subst : %v, applied subst : %v, subst_found : %v",
+				len(args.children),
+				len(args.substsBT),
+				len(args.formsBT),
+				args.st.GetBTOnFormulas(),
+				Core.SubstAndFormListToString(args.givenSubsts),
+				args.st.GetAppliedSubst().ToString(),
+				Core.SubstAndFormListToString(args.st.GetSubstsFound()))
+		}),
+	)
+	Glob.PrintDebug("WC", Lib.MkLazy(func() string {
+		return fmt.Sprintf(
+			"MM : %v",
+			Lib.ListToString(args.st.GetMM().Elements(), ",", "[]"),
+		)
+	}))
+	Glob.PrintDebug("WC", Lib.MkLazy(func() string {
+		return fmt.Sprintf(
+			"MC : %v",
+			Lib.ListToString(args.st.GetMC().Elements(), ",", "[]"),
+		)
+	}))
 }
 
 /* Utilitary subfunctions */
 
 func (ds *destructiveSearch) childrenClosedByThemselves(args wcdArgs, proofChildren [][]ProofStruct) error {
-	Glob.PrintDebug("WC", "All children has finished by themselves")
+	Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "All children has finished by themselves" }))
 
 	// All children are closed & did not send any subst, i.e., they can be closed.
 	closeChildren(&args.children, true)
@@ -131,19 +159,40 @@ func (ds *destructiveSearch) childrenClosedByThemselves(args wcdArgs, proofChild
 }
 
 func (ds *destructiveSearch) passSubstToParent(args wcdArgs, proofChildren [][]ProofStruct, substs []Core.SubstAndForm) error {
-	Glob.PrintDebug("WC", fmt.Sprintf("All children agree on the substitution(s) : %v", Unif.SubstListToString(Core.GetSubstListFromSubstAndFormList(substs))))
+	Glob.PrintDebug(
+		"WC",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"All children agree on the substitution(s) : %v",
+				Unif.SubstListToString(Core.GetSubstListFromSubstAndFormList(substs)))
+		}),
+	)
 
 	// Updates the proof with what the children have found
 	args.st = updateProof(args, proofChildren)
 	newMetas := args.toReintroduce
-	Glob.PrintDebug("WC", fmt.Sprintf("new meta to reintroduce: %v", Glob.IntListToString(newMetas)))
+	Glob.PrintDebug(
+		"WC",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"new meta to reintroduce: %v",
+				Glob.IntListToString(newMetas))
+		}),
+	)
 
 	// Remove all the metas introduced by the current node to only retrieve relevant ones for the parent.
 	resultingSubstsAndForms := []Core.SubstAndForm{}
 	resultingSubsts := []Unif.Substitutions{}
 
 	for _, subst := range substs {
-		Glob.PrintDebug("WC", fmt.Sprintf("Check the susbt, remove useless element and merge with applied subst :%v", subst.GetSubst().ToString()))
+		Glob.PrintDebug(
+			"WC",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf(
+					"Check the susbt, remove useless element and merge with applied subst :%v",
+					subst.GetSubst().ToString())
+			}),
+		)
 		err, merged := Core.MergeSubstAndForm(subst, args.st.GetAppliedSubst())
 
 		if err != nil {
@@ -174,10 +223,17 @@ func (ds *destructiveSearch) passSubstToParent(args wcdArgs, proofChildren [][]P
 			}
 
 			newMetas = Glob.UnionIntList(newMetas, retrieveMetaFromSubst(cleaned))
-			Glob.PrintDebug("WC", fmt.Sprintf("New meta to reintroduce in loop: %v - %v ", Glob.IntListToString(newMetas), Glob.IntListToString(retrieveMetaFromSubst(cleaned))))
+			Glob.PrintDebug(
+				"WC",
+				Lib.MkLazy(func() string {
+					return fmt.Sprintf(
+						"New meta to reintroduce in loop: %v - %v ",
+						Glob.IntListToString(newMetas),
+						Glob.IntListToString(retrieveMetaFromSubst(cleaned)))
+				}))
 
 		} else {
-			Glob.PrintDebug("WC", "Subst empty")
+			Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Subst empty" }))
 		}
 	}
 
@@ -200,7 +256,14 @@ func (ds *destructiveSearch) passSubstToParent(args wcdArgs, proofChildren [][]P
 // If there is a problem of a child always checking the same substitution, it can be avoided here.
 func (bs *destructiveSearch) passSubstToChildren(args wcdArgs, substs []Core.SubstAndForm) {
 	subst, resultingSubsts := bs.chooseSubstitutionDestructive(Core.CopySubstAndFormList(substs), args.st.GetMM())
-	Glob.PrintDebug("WC", fmt.Sprintf("There is more than one substitution, choose one : %v and send it to children", subst.ToString()))
+	Glob.PrintDebug(
+		"WC",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"There is more than one substitution, choose one : %v and send it to children",
+				subst.ToString())
+		}),
+	)
 
 	sendSubToChildren(args.children, subst)
 
@@ -214,7 +277,12 @@ func (bs *destructiveSearch) passSubstToChildren(args wcdArgs, substs []Core.Sub
 }
 
 func (ds *destructiveSearch) manageOpenedChild(args wcdArgs) {
-	Glob.PrintDebug("WC", "Open children previously found, tell to children to wait for me and try another substitution")
+	Glob.PrintDebug(
+		"WC",
+		Lib.MkLazy(func() string {
+			return "Open children previously found, tell to children to wait for me and try another substitution"
+		}),
+	)
 	closeChildren(&args.children, false)
 
 	// If the completeness mode is active, then we need to deal with forbidden substitutions.
@@ -223,10 +291,10 @@ func (ds *destructiveSearch) manageOpenedChild(args wcdArgs) {
 	}
 
 	if args.st.GetBTOnFormulas() && len(args.formsBT) > 0 {
-		Glob.PrintDebug("WC", "Backtrack on DMT formulas.")
+		Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Backtrack on DMT formulas." }))
 		ds.manageBacktrackForDMT(args)
 	} else if len(args.substsBT) > 0 {
-		Glob.PrintDebug("WC", "Backtrack on substitutions.")
+		Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Backtrack on substitutions." }))
 		newSubst := ds.tryBTSubstitution(&args.substsBT, args.st.GetMM(), args.children)
 		WriteExchanges(args.fatherId, args.st, []Core.SubstAndForm{newSubst}, Core.MakeEmptySubstAndForm(), "WaitChildren - Backtrack on substitutions.")
 		// Mutually exclusive cases: when a backtrack is done on substitutions, this backtrack is prioritised from now on.
@@ -234,18 +302,27 @@ func (ds *destructiveSearch) manageOpenedChild(args wcdArgs) {
 		args.overwrite = false
 		ds.waitChildren(args)
 	} else {
-		Glob.PrintDebug("WC", "A child is opened but no more backtracks are available.")
+		Glob.PrintDebug(
+			"WC",
+			Lib.MkLazy(func() string { return "A child is opened but no more backtracks are available." }),
+		)
 		WriteExchanges(args.fatherId, args.st, args.givenSubsts, args.currentSubst, "WaitChildren - Die - No more BT available")
 
 		// In the complete version, we just have to restart the proofsearch forbidding the bad substitutions.
 		if Glob.GetCompleteness() && len(args.children) > 1 && !args.currentSubst.IsEmpty() {
-			Glob.PrintDebug("WC", "Restart proof with forbidden substitutions.")
+			Glob.PrintDebug(
+				"WC",
+				Lib.MkLazy(func() string { return "Restart proof with forbidden substitutions." }),
+			)
 			sendForbiddenToChildren(args.children, args.st.GetForbiddenSubsts())
 			args.overwrite = false
 			args.currentSubst = Core.MakeEmptySubstAndForm()
 			ds.waitChildren(args)
 		} else {
-			Glob.PrintDebug("WC", "No solution. You should launch in complete mode.")
+			Glob.PrintDebug(
+				"WC",
+				Lib.MkLazy(func() string { return "No solution. You should launch in complete mode." }),
+			)
 			closeChildren(&args.children, true)
 			ds.sendSubToFather(args.c, false, true, args.fatherId, args.st, args.givenSubsts, args.nodeId, args.originalNodeId, args.toReintroduce)
 		}
@@ -273,7 +350,7 @@ func (ds *destructiveSearch) manageBacktrackForDMT(args wcdArgs) {
 	copiedState := args.st.Copy()
 	communicationChild := Communication{make(chan bool), make(chan Result)}
 	go ds.ProofSearch(Glob.GetGID(), copiedState, communicationChild, nextSaF.GetSaf().ToSubstAndForm(), childNode, args.originalNodeId, args.toReintroduce, false)
-	Glob.PrintDebug("PS", "GO !")
+	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "GO !" }))
 	Glob.IncrGoRoutine(1)
 
 	args.children = []Communication{communicationChild}

--- a/src/Search/exchanges.go
+++ b/src/Search/exchanges.go
@@ -128,7 +128,7 @@ func makeJsonExchanges(father_uint uint64, st State, ss_subst []Unif.Substitutio
 func WriteExchanges(father uint64, st State, sub_sent []Core.SubstAndForm, subst_received Core.SubstAndForm, calling_function string) {
 	if Glob.GetExchanges() {
 		mutex_file_exchanges.Lock()
-		Glob.PrintDebug("WG", calling_function)
+		Glob.PrintDebug("WG", Lib.MkLazy(func() string { return calling_function }))
 		os_stat, _ := os.Stat(graph_file_name_exchanges)
 		if os_stat.Size() != 0 {
 			file_exchanges.WriteString(",\n")

--- a/src/Search/incremental/rules.go
+++ b/src/Search/incremental/rules.go
@@ -199,7 +199,7 @@ type AlphaAnd struct {
 
 func (aa *AlphaAnd) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(aa.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(aa.FullString) }))
 
 	switch form := aa.GetForm().(type) {
 	case AST.And:
@@ -217,7 +217,7 @@ type AlphaNotNot struct {
 
 func (ann *AlphaNotNot) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(ann.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(ann.FullString) }))
 
 	switch form := ann.GetForm().(type) {
 	case AST.Not:
@@ -236,7 +236,7 @@ type AlphaNotOr struct {
 
 func (ano *AlphaNotOr) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(ano.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(ano.FullString) }))
 
 	switch form := ano.GetForm().(type) {
 	case AST.Not:
@@ -257,7 +257,7 @@ type AlphaNotImp struct {
 
 func (ani *AlphaNotImp) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(ani.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(ani.FullString) }))
 
 	switch form := ani.GetForm().(type) {
 	case AST.Not:
@@ -277,7 +277,7 @@ type BetaNotAnd struct {
 
 func (bna *BetaNotAnd) apply() []RuleList {
 	resultRulesBeta := []RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(bna.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bna.FullString) }))
 
 	switch form := bna.GetForm().(type) {
 	case AST.Not:
@@ -299,7 +299,7 @@ type BetaNotEqu struct {
 func (bne *BetaNotEqu) apply() []RuleList {
 	resultRules1 := RuleList{}
 	resultRules2 := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(bne.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bne.FullString) }))
 
 	switch form := bne.GetForm().(type) {
 	case AST.Not:
@@ -322,7 +322,7 @@ type BetaOr struct {
 
 func (bo *BetaOr) apply() []RuleList {
 	resultRulesBeta := []RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(bo.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bo.FullString) }))
 
 	switch form := bo.GetForm().(type) {
 	case AST.Or:
@@ -341,7 +341,7 @@ type BetaImp struct {
 func (bi *BetaImp) apply() []RuleList {
 	resultRules1 := RuleList{}
 	resultRules2 := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(bi.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bi.FullString) }))
 
 	switch subForm := bi.GetForm().(type) {
 	case AST.Imp:
@@ -359,7 +359,7 @@ type BetaEqu struct {
 func (be *BetaEqu) apply() []RuleList {
 	resultRules1 := RuleList{}
 	resultRules2 := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(be.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(be.FullString) }))
 
 	switch form := be.GetForm().(type) {
 	case AST.Equ:
@@ -387,7 +387,7 @@ type GammaNotExists struct {
 
 func (gne *GammaNotExists) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(gne.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(gne.FullString) }))
 
 	instanciatedForm, metas := Core.Instantiate(Core.MakeFormAndTerm(gne.GetForm(), gne.GetTerms()), 42)
 	newTerms := gne.GetTerms().Copy(AST.Term.Copy)
@@ -428,7 +428,7 @@ type GammaForall struct {
 
 func (gf *GammaForall) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(gf.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(gf.FullString) }))
 
 	instanciatedForm, metas := Core.Instantiate(Core.MakeFormAndTerm(gf.GetForm(), gf.GetTerms()), 42)
 	newTerms := gf.GetTerms().Copy(AST.Term.Copy)
@@ -466,7 +466,7 @@ type DeltaNotForall struct {
 
 func (dnf *DeltaNotForall) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(dnf.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(dnf.FullString) }))
 
 	skolemizedForm := Core.Skolemize(dnf.GetForm(), dnf.GetForm().GetMetas())
 	skolemizedFnt := Core.MakeFormAndTerm(skolemizedForm, dnf.GetTerms())
@@ -485,7 +485,7 @@ type DeltaExists struct {
 
 func (de *DeltaExists) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", "Applying "+fmt.Sprint(de.FullString))
+	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(de.FullString) }))
 
 	skolemizedForm := Core.Skolemize(de.GetForm(), de.GetForm().GetMetas())
 	skolemizedFnt := Core.MakeFormAndTerm(skolemizedForm, de.GetTerms())

--- a/src/Search/nonDestructiveSearch.go
+++ b/src/Search/nonDestructiveSearch.go
@@ -59,7 +59,7 @@ func (nds *nonDestructiveSearch) setApplyRules(function func(uint64, State, Comm
 }
 
 func (nds *nonDestructiveSearch) doEndManageBeta(fatherId uint64, state State, c Communication, channels []Communication, currentNodeId int, originalNodeId int, childIds []int, metaToReintroduce []int) {
-	Glob.PrintDebug("PS", "Die")
+	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Die" }))
 }
 
 func (nds *nonDestructiveSearch) manageRewriteRules(fatherId uint64, state State, c Communication, newAtomics Core.FormAndTermsList, currentNodeId int, originalNodeId int, metaToReintroduce []int) {
@@ -141,11 +141,17 @@ func (nds *nonDestructiveSearch) catchFormulaToInstantiate(subst_found Unif.Subs
 * Got the substitution (X, a) and reintroduce ForAll x P(x) -> need to reintroduce P(a). Remplace immediatly the new generated metavariable by a.
 **/
 func (nds *nonDestructiveSearch) instantiate(fatherId uint64, state *State, c Communication, index int, s Core.SubstAndForm) {
-	Glob.PrintDebug("PS", fmt.Sprintf("Instantiate with subst : %v ", s.GetSubst().ToString()))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Instantiate with subst : %v ", s.GetSubst().ToString()) }),
+	)
 	newMetaGenerator := state.GetMetaGen()
 	reslf := Core.ReintroduceMeta(&newMetaGenerator, index, state.GetN())
 	state.SetMetaGen(newMetaGenerator)
-	Glob.PrintDebug("PS", fmt.Sprintf("Instantiate the formula : %s", reslf.ToString()))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Instantiate the formula : %s", reslf.ToString()) }),
+	)
 
 	// Apply gamma rule
 	newLf, newMetas := ApplyGammaRules(reslf, index, state)
@@ -196,7 +202,15 @@ func (nds *nonDestructiveSearch) instantiate(fatherId uint64, state *State, c Co
 			}
 		}
 		if !found {
-			Glob.PrintDebug("PS", fmt.Sprintf("Error : No matching found for %v in new formula : %v\n", new_meta.ToString(), s.GetForm().ToString()))
+			Glob.PrintDebug(
+				"PS",
+				Lib.MkLazy(func() string {
+					return fmt.Sprintf(
+						"Error : No matching found for %v in new formula : %v\n",
+						new_meta.ToString(),
+						s.GetForm().ToString())
+				}),
+			)
 		}
 	}
 
@@ -231,8 +245,21 @@ func (nds *nonDestructiveSearch) instantiate(fatherId uint64, state *State, c Co
 	// 	}
 	// }
 
-	Glob.PrintDebug("PS", fmt.Sprintf("Applied subst: %s", state.GetAppliedSubst().GetSubst().ToString()))
-	Glob.PrintDebug("PS", fmt.Sprintf("Real substitution applied : %s", new_subst.ToString()))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Applied subst: %s",
+				state.GetAppliedSubst().GetSubst().ToString())
+		}),
+	)
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Real substitution applied : %s", new_subst.ToString())
+		}),
+	)
 
 	state.SetLF(Core.ApplySubstitutionsOnFormAndTermsList(new_subst, state.GetLF()))
 
@@ -275,21 +302,29 @@ func (nds *nonDestructiveSearch) manageSubstFoundNonDestructive(father_id uint64
 	}
 
 	choosenSubstMetas := new_choosen_subst.GetSubst().GetMeta()
-	Glob.PrintDebug("PS", fmt.Sprintf(
-		"Choosen subst : %v - HasInCommon : %v",
-		new_choosen_subst.GetSubst().ToString(),
-		AST.HasMetaInCommonWith(
-			choosenSubstMetas,
-			st.GetLastAppliedSubst().GetSubst().GetMeta(),
-		),
-	))
-	Glob.PrintDebug("PS", fmt.Sprintf("AreRulesApplicable : %v", st.AreRulesApplicable()))
+	Glob.PrintDebug("PS", Lib.MkLazy(func() string {
+		return fmt.Sprintf(
+			"Choosen subst : %v - HasInCommon : %v",
+			new_choosen_subst.GetSubst().ToString(),
+			AST.HasMetaInCommonWith(
+				choosenSubstMetas,
+				st.GetLastAppliedSubst().GetSubst().GetMeta(),
+			),
+		)
+	}))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("AreRulesApplicable : %v", st.AreRulesApplicable()) }),
+	)
 
 	choosen_subst = new_choosen_subst
 
 	// Catch all the meta which can be instantiate
 	form_to_instantiate = nds.catchFormulaToInstantiate(choosen_subst.GetSubst())
-	Glob.PrintDebug("PS", fmt.Sprintf("Form_to_instantiate : %v", form_to_instantiate))
+	Glob.PrintDebug(
+		"PS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Form_to_instantiate : %v", form_to_instantiate) }),
+	)
 
 	return form_to_instantiate, choosen_subst
 }
@@ -304,7 +339,7 @@ func (nds *nonDestructiveSearch) manageSubstFoundNonDestructive(father_id uint64
 * subst_found : Unif.Substitutions found by this process
 **/
 
-//ILL TODO: Redo the non-destructive search, in particular, this function.
+//FIXME: Redo the non-destructive search, in particular, this function.
 //Both this search and the destructive search should be refactored so the similarities arise in a single struct BasicSearch
 /*
 func (nds *nonDestructiveSearch) proofSearch(father_id uint64, st State, c Communication, s Core.SubstAndForm, node_id int, original_node_id int, meta_to_reintroduce []int) {
@@ -368,7 +403,10 @@ func (ds *nonDestructiveSearch) manageResult(c Communication) (Core.Unifier, []P
 
 		time.Sleep(1 * time.Millisecond)
 
-		Glob.PrintDebug("MAIN", fmt.Sprintf("open is : %v from %v", open, res.getId()))
+		Glob.PrintDebug(
+			"MAIN",
+			Lib.MkLazy(func() string { return fmt.Sprintf("open is : %v from %v", open, res.getId()) }),
+		)
 		Glob.PrintInfo("MAIN", fmt.Sprintf("%v goroutines still running - %v goroutines generated", runtime.NumGoroutine(), Glob.GetNbGoroutines()))
 	}
 

--- a/src/Search/rules.go
+++ b/src/Search/rules.go
@@ -70,7 +70,7 @@ var strToPrintMap map[string]string = map[string]string{
 *	a substitution, the substitution which make the contradiction (possibly empty)
 **/
 func ApplyClosureRules(form AST.Form, state *State) (result bool, substitutions []Unif.Substitutions) {
-	Glob.PrintDebug("ACR", "Start ACR")
+	Glob.PrintDebug("ACR", Lib.MkLazy(func() string { return "Start ACR" }))
 
 	if searchObviousClosureRule(form) {
 		return true, substitutions
@@ -87,10 +87,10 @@ func ApplyClosureRules(form AST.Form, state *State) (result bool, substitutions 
 	substFound, matchSubsts := searchClosureRule(f, *state)
 
 	if substFound {
-		Glob.PrintDebug("ACR", "Subst found")
+		Glob.PrintDebug("ACR", Lib.MkLazy(func() string { return "Subst found" }))
 
 		for _, subst := range matchSubsts {
-			Glob.PrintDebug("ACR", fmt.Sprintf("MSL : %v", subst.ToString()))
+			Glob.PrintDebug("ACR", Lib.MkLazy(func() string { return fmt.Sprintf("MSL : %v", subst.ToString()) }))
 
 			if subst.GetSubst().Equals(Unif.MakeEmptySubstitution()) {
 				result = true
@@ -101,7 +101,16 @@ func ApplyClosureRules(form AST.Form, state *State) (result bool, substitutions 
 			}
 
 			if result {
-				Glob.PrintDebug("ACR", fmt.Sprintf("Subst found between : %v and %v : %v", form.ToString(), subst.GetForm().ToString(), subst.GetSubst().ToString()))
+				Glob.PrintDebug(
+					"ACR",
+					Lib.MkLazy(func() string {
+						return fmt.Sprintf(
+							"Subst found between : %v and %v : %v",
+							form.ToString(),
+							subst.GetForm().ToString(),
+							subst.GetSubst().ToString())
+					}),
+				)
 				substitutions = Unif.AppendIfNotContainsSubst(substitutions, subst.GetSubst())
 			}
 		}
@@ -128,12 +137,12 @@ func searchForbidden(state *State, s Unif.MatchingSubstitutions) bool {
 func searchObviousClosureRule(f AST.Form) bool {
 	switch nf := f.(type) {
 	case AST.Bot:
-		Glob.PrintDebug("AR", "⊥ found !")
+		Glob.PrintDebug("AR", Lib.MkLazy(func() string { return "⊥ found !" }))
 		return true
 	case AST.Not:
 		switch nf.GetForm().(type) {
 		case AST.Top:
-			Glob.PrintDebug("AR", "¬⊤ found !")
+			Glob.PrintDebug("AR", Lib.MkLazy(func() string { return "¬⊤ found !" }))
 			return true
 		default:
 			return false
@@ -151,17 +160,33 @@ func searchInequalities(form AST.Form) (bool, Unif.Substitutions) {
 		if predNeq, isPred := formNot.GetForm().(AST.Pred); isPred {
 			if predNeq.GetID().Equals(AST.Id_eq) {
 
-				Glob.PrintDebug("SI", fmt.Sprintf("Search Inequality closure rule : %v", form.ToString()))
+				Glob.PrintDebug(
+					"SI",
+					Lib.MkLazy(func() string {
+						return fmt.Sprintf(
+							"Search Inequality closure rule : %v",
+							form.ToString())
+					}),
+				)
 
 				// Search if the two terms are unfiable
 				arg_1 := predNeq.GetArgs().At(0)
 				arg_2 := predNeq.GetArgs().At(1)
 
-				Glob.PrintDebug("SI", fmt.Sprintf("Arg 1 : %v", arg_1.ToString()))
-				Glob.PrintDebug("SI", fmt.Sprintf("Arg 2 : %v", arg_2.ToString()))
+				Glob.PrintDebug(
+					"SI",
+					Lib.MkLazy(func() string { return fmt.Sprintf("Arg 1 : %v", arg_1.ToString()) }),
+				)
+				Glob.PrintDebug(
+					"SI",
+					Lib.MkLazy(func() string { return fmt.Sprintf("Arg 2 : %v", arg_2.ToString()) }),
+				)
 
 				subst = Unif.AddUnification(arg_1, arg_2, subst)
-				Glob.PrintDebug("SI", fmt.Sprintf("Subst : %v", subst.ToString()))
+				Glob.PrintDebug(
+					"SI",
+					Lib.MkLazy(func() string { return fmt.Sprintf("Subst : %v", subst.ToString()) }),
+				)
 
 				if !subst.Equals(Unif.Failure()) {
 					return true, subst
@@ -199,7 +224,7 @@ func setStateRules(state *State, name string, forms ...string) {
 		strWords += "_" + val
 	}
 
-	Glob.PrintDebug("AR", "Applying "+strChars+"...")
+	Glob.PrintDebug("AR", Lib.MkLazy(func() string { return "Applying " + strChars + "..." }))
 
 	state.SetCurrentProofRule(strChars)
 	state.SetCurrentProofRuleName(strWords)

--- a/src/Search/search.go
+++ b/src/Search/search.go
@@ -42,6 +42,7 @@ import (
 	"github.com/GoelandProver/Goeland/AST"
 	"github.com/GoelandProver/Goeland/Core"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Unif"
 )
 
@@ -69,8 +70,11 @@ func SetApplyRules(function func(uint64, State, Communication, Core.FormAndTerms
 
 /* Begin the proof search */
 func Search(formula AST.Form, bound int) {
-	Glob.PrintDebug("MAIN", "Start search")
-	Glob.PrintDebug("MAIN", fmt.Sprintf("Initial formula: %v", formula.ToString()))
+	Glob.PrintDebug("MAIN", Lib.MkLazy(func() string { return "Start search" }))
+	Glob.PrintDebug(
+		"MAIN",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Initial formula: %v", formula.ToString()) }),
+	)
 
 	UsedSearch.Search(formula, bound)
 }

--- a/src/Search/state.go
+++ b/src/Search/state.go
@@ -292,75 +292,89 @@ func MakeState(limit int, tp, tn Unif.DataStructure, f AST.Form) State {
 
 /* Print a state */
 func (st State) Print() {
-	Glob.PrintDebug("PSt", "==== State ====")
-	Glob.PrintDebug("PSt", fmt.Sprintf(" n = %v", st.GetN()))
+	Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "==== State ====" }))
+	Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return fmt.Sprintf(" n = %v", st.GetN()) }))
 
 	if !st.GetLF().IsEmpty() {
-		Glob.PrintDebug("Pst", "Formulas list: ")
+		Glob.PrintDebug("Pst", Lib.MkLazy(func() string { return "Formulas list: " }))
 		st.GetLF().Print()
 	}
 
 	if !st.GetAtomic().IsEmpty() {
-		Glob.PrintDebug("PSt", "Atomic formulas: ")
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Atomic formulas: " }))
 		st.GetAtomic().Print()
 	}
 
 	if !st.GetAlpha().IsEmpty() {
-		Glob.PrintDebug("PSt", "Alpha formulas: ")
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Alpha formulas: " }))
 		st.GetAlpha().Print()
 	}
 
 	if !st.GetBeta().IsEmpty() {
-		Glob.PrintDebug("PSt", "Beta formulas: ")
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Beta formulas: " }))
 		st.GetBeta().Print()
 	}
 
 	if !st.GetDelta().IsEmpty() {
-		Glob.PrintDebug("PSt", "Delta formulas: ")
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Delta formulas: " }))
 		st.GetDelta().Print()
 	}
 
 	if !st.GetGamma().IsEmpty() {
-		Glob.PrintDebug("PSt", "Gamma formulas: ")
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Gamma formulas: " }))
 		st.GetGamma().Print()
 	}
 
 	if len(st.GetMetaGen()) > 0 {
-		Glob.PrintDebug("PSt", "Meta generator formulas: ")
-		Glob.PrintDebug("PSt", Core.MetaGenListToString(st.GetMetaGen()))
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Meta generator formulas: " }))
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return Core.MetaGenListToString(st.GetMetaGen()) }))
 	}
 
 	if !st.GetMM().IsEmpty() {
-		Glob.PrintDebug("PSt", "Meta Mother: ")
-		Glob.PrintDebug("Pst", Lib.ListToString(st.GetMM().Elements(), ",", "[]"))
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Meta Mother: " }))
+		Glob.PrintDebug(
+			"Pst",
+			Lib.MkLazy(func() string { return Lib.ListToString(st.GetMM().Elements(), ",", "[]") }),
+		)
 	}
 
 	if !st.GetMC().IsEmpty() {
-		Glob.PrintDebug("PSt", "Meta current: ")
-		Glob.PrintDebug("Pst", Lib.ListToString(st.GetMC().Elements(), ",", "[]"))
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Meta current: " }))
+		Glob.PrintDebug(
+			"Pst",
+			Lib.MkLazy(func() string { return Lib.ListToString(st.GetMC().Elements(), ",", "[]") }),
+		)
 	}
 
 	if !st.GetAppliedSubst().IsEmpty() {
-		Glob.PrintDebug("PSt", "Applied subst: ")
-		Glob.PrintDebug("PSt", st.GetAppliedSubst().ToString())
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Applied subst: " }))
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return st.GetAppliedSubst().ToString() }))
 	}
 
 	if len(st.GetSubstsFound()) > 0 {
-		Glob.PrintDebug("PSt", "Subst_found: ")
-		Glob.PrintDebug("PSt", Unif.SubstListToString(Core.GetSubstListFromSubstAndFormList(st.GetSubstsFound())))
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Subst_found: " }))
+		Glob.PrintDebug(
+			"PSt",
+			Lib.MkLazy(func() string {
+				return Unif.SubstListToString(Core.GetSubstListFromSubstAndFormList(st.GetSubstsFound()))
+			}),
+		)
 	}
 
 	if !st.GetLastAppliedSubst().IsEmpty() {
-		Glob.PrintDebug("PSt", "Last applied subst:")
-		Glob.PrintDebug("PSt", st.GetLastAppliedSubst().ToString())
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Last applied subst:" }))
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return st.GetLastAppliedSubst().ToString() }))
 	}
 
 	if len(st.forbidden) > 0 {
-		Glob.PrintDebug("PSt", "Forbidden:")
-		Glob.PrintDebug("PSt", Unif.SubstListToString(st.forbidden))
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Forbidden:" }))
+		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return Unif.SubstListToString(st.forbidden) }))
 	}
 
-	Glob.PrintDebug("PSt", fmt.Sprintf("BT on formulas : %v", st.GetBTOnFormulas()))
+	Glob.PrintDebug(
+		"PSt",
+		Lib.MkLazy(func() string { return fmt.Sprintf("BT on formulas : %v", st.GetBTOnFormulas()) }),
+	)
 
 }
 
@@ -451,8 +465,11 @@ func (st State) AreRulesApplicable() bool {
 
 /* Put the given formula in the right rule box in the given state */
 func (st *State) DispatchForm(f Core.FormAndTerms) {
-	Glob.PrintDebug("DF", fmt.Sprintf("Dispatch the form : %v ", f.ToString()))
-	Glob.PrintDebug("DF", fmt.Sprintf("Kind of rule : %v ", Core.ShowKindOfRule(f.GetForm())))
+	Glob.PrintDebug("DF", Lib.MkLazy(func() string { return fmt.Sprintf("Dispatch the form : %v ", f.ToString()) }))
+	Glob.PrintDebug(
+		"DF",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Kind of rule : %v ", Core.ShowKindOfRule(f.GetForm())) }),
+	)
 	switch Core.ShowKindOfRule(f.GetForm()) {
 	case Core.Atomic:
 		st.SetAtomic(st.GetAtomic().AppendIfNotContains(f))

--- a/src/Tests/DMT/equ_test.go
+++ b/src/Tests/DMT/equ_test.go
@@ -46,6 +46,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/GoelandProver/Goeland/Lib"
 	treetypes "github.com/GoelandProver/Goeland/code-trees/tree-types"
 	"github.com/GoelandProver/Goeland/global"
 	dmt "github.com/GoelandProver/Goeland/modules/dmt"
@@ -573,7 +574,9 @@ func TestSubst1(t *testing.T) {
 			basictypes.MakerAnd(basictypes.NewFormList(basictypes.MakerPred(Q, basictypes.NewTermList(x, x), []typing.TypeApp{}), basictypes.MakerPred(P, basictypes.NewTermList(x, x), []typing.TypeApp{}))),
 		),
 	)
-	global.PrintDebug("TS1", fmt.Sprintf("equpred : %v", equPred.ToString()))
+	global.PrintDebug(
+		"TS1",
+		Lib.MkLazy(func() string { return fmt.Sprintf("equpred : %v", equPred.ToString()) }))
 
 	if !dmt.RegisterAxiom(equPred) {
 		t.Fatalf("Error: %s hasn't been registered as a rewrite rule.", equPred.ToString())
@@ -583,7 +586,10 @@ func TestSubst1(t *testing.T) {
 	Z := basictypes.MakerMeta("Z", 1)
 
 	form := basictypes.MakerPred(P, basictypes.NewTermList(Y, Z), []typing.TypeApp{})
-	global.PrintDebug("TS1", fmt.Sprintf("form : %v", form.ToString()))
+	global.PrintDebug(
+		"TS1",
+		Lib.MkLazy(func() string { return fmt.Sprintf("form : %v", form.ToString()) }),
+	)
 
 	substs, err := dmt.Rewrite(form)
 
@@ -595,7 +601,10 @@ func TestSubst1(t *testing.T) {
 		t.Fatalf("Error: more than one rewrite rule found for %s when it should have only one.", form.ToString())
 	}
 
-	global.PrintDebug("TS1", fmt.Sprintf("after form : %v", form.ToString()))
+	global.PrintDebug(
+		"TS1",
+		Lib.MkLazy(func() string { return fmt.Sprintf("after form : %v", form.ToString()) }),
+	)
 	forms := substs[0].GetSaf().GetForm()
 	subst := substs[0].GetSaf().GetSubst()
 

--- a/src/Typing/term_rules.go
+++ b/src/Typing/term_rules.go
@@ -152,7 +152,7 @@ func getArgsTypes(
 			types = append(types, tmpTerm.GetTypeApp())
 		// There shouldn't be Metas yet.
 		case AST.Meta:
-			Glob.PrintDebug("GAT", "Found a Meta while typing everything.")
+			Glob.PrintDebug("GAT", Lib.MkLazy(func() string { return "Found a Meta while typing everything." }))
 			// ID is filtered out
 		}
 	}

--- a/src/Unif/code-trees.go
+++ b/src/Unif/code-trees.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/GoelandProver/Goeland/AST"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 )
 
 /*************************/
@@ -183,8 +184,6 @@ func (n Node) Print() {
 	n.printAux(-1)
 }
 
-//ILL TODO: A Print function should not print, it should return a String that is then printed
-//Why is there a debug print followed by a normal print ?
 /* Auxiliary function to print a CodeTree. */
 func (n Node) printAux(tab int) {
 	// Print current value
@@ -192,8 +191,7 @@ func (n Node) printAux(tab int) {
 		if instr.IsEquivalent(Begin{}) {
 			tab += 1
 		}
-		Glob.PrintDebug("PT", strings.Repeat("\t", tab)+instr.ToString())
-		// fmt.Printf(strings.Repeat("\t", tab) + instr.ToString() + "\n")
+		Glob.PrintDebug("PT", Lib.MkLazy(func() string { return strings.Repeat("\t", tab) + instr.ToString() }))
 
 		if IsEnd(instr) {
 			tab -= 1
@@ -202,11 +200,10 @@ func (n Node) printAux(tab int) {
 
 	if n.isLeaf() {
 		for _, form := range n.formulae.Slice() {
-			Glob.PrintDebug("PT", strings.Repeat("\t", tab+1)+form.ToString())
-			// fmt.Printf(strings.Repeat("\t", tab+1) + form.ToString() + "\n")
+			Glob.PrintDebug("PT", Lib.MkLazy(func() string { return strings.Repeat("\t", tab+1) + form.ToString() }))
 		}
 	}
-	Glob.PrintDebug("PT", "\n")
+	Glob.PrintDebug("PT", Lib.MkLazy(func() string { return "\n" }))
 
 	// For each child, print the following sequences with tab = tab + 1
 	for _, child := range n.children {

--- a/src/Unif/machine.go
+++ b/src/Unif/machine.go
@@ -106,12 +106,9 @@ func (m *Machine) unwrapMeta(term AST.Term) AST.Term {
 	deja_vu := map[int]bool{}
 	for term.IsMeta() {
 		val, ok := m.meta.Get(term.ToMeta())
-		// global.PrintDebug("UM", fmt.Sprintf("ok : %v", ok))
 		if (ok == -1) || deja_vu[term.GetIndex()] {
 			break
 		}
-		// global.PrintDebug("UM", fmt.Sprintf("ok 2 : %v", ok))
-		// global.PrintDebug("UM", fmt.Sprintf("Val : %v", val.ToString()))
 		deja_vu[term.GetIndex()] = true
 		term = val.Copy()
 	}
@@ -170,11 +167,9 @@ func (m *Machine) tryUnlock(instrTerm AST.Term) Status {
 	if m.isLocked() && m.beginCount == m.beginLock {
 		m.unlockMachine()
 		if errorOccured(m.trySubstituteMeta(m.getCurrentMeta(), instrTerm.Copy())) {
-			// global.PrintDebug("TU", "ERROR in ATTM")
 			return Status(ERROR)
 		}
 		if errorOccured(m.lockedRight()) {
-			// global.PrintDebug("TU", "ERROR in LR")
 			return Status(ERROR)
 		}
 	}

--- a/src/Unif/matching.go
+++ b/src/Unif/matching.go
@@ -51,7 +51,6 @@ import (
 func (n Node) Unify(formula AST.Form) (bool, []MatchingSubstitutions) {
 	machine := makeMachine()
 	res := machine.unify(n, formula)
-	// Glob.PrintDebug("Unify", fmt.Sprintf("Res = %v", !reflect.DeepEqual(machine.failure, res)))
 	return !reflect.DeepEqual(machine.failure, res), res // return found, res
 }
 
@@ -95,19 +94,54 @@ func (m *Machine) unify(node Node, formula AST.Form) []MatchingSubstitutions {
 func (m *Machine) unifyAux(node Node) []MatchingSubstitutions {
 	for _, instr := range node.value {
 
-		Glob.PrintDebug("UX", "------------------------")
-		Glob.PrintDebug("UX", fmt.Sprintf("Instr: %v", instr.ToString()))
-		Glob.PrintDebug("UX", fmt.Sprintf("Meta : %v", m.meta.ToString()))
-		Glob.PrintDebug("UX", fmt.Sprintf("Subst : %v", SubstPairListToString(m.subst)))
-		Glob.PrintDebug("UX", fmt.Sprintf("Post : %v", IntPairistToString(m.post)))
-		Glob.PrintDebug("UX", fmt.Sprintf("IsLocked : %v", m.isLocked()))
-		Glob.PrintDebug("UX", fmt.Sprintf("HasPushed : %v", m.hasPushed))
-		Glob.PrintDebug("UX", fmt.Sprintf("HasPoped : %v", m.hasPoped))
-		Glob.PrintDebug("UX", fmt.Sprintf("m.beginCount: %v - m.beginLock : %v", m.beginCount, m.beginLock))
-		Glob.PrintDebug("UX", fmt.Sprintf("m.TopLevelCount: %v - m.TopLevelTot : %v", m.topLevelCount, m.topLevelTot))
-		Glob.PrintDebug("UX", fmt.Sprintf("Cursor: %v/%v", m.q, m.terms.Len()))
-		Glob.PrintDebug("UX", fmt.Sprintf("m.terms[cursor] : %v", m.terms.At(m.q).ToString()))
-		Glob.PrintDebug("UX", fmt.Sprintf("m.terms : %v", m.terms.ToString(AST.Term.ToString, ",", "{}")))
+		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return "------------------------" }))
+		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("Instr: %v", instr.ToString()) }))
+		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("Meta : %v", m.meta.ToString()) }))
+		Glob.PrintDebug(
+			"UX",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Subst : %v", SubstPairListToString(m.subst)) }),
+		)
+		Glob.PrintDebug(
+			"UX",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Post : %v", IntPairistToString(m.post)) }),
+		)
+		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("IsLocked : %v", m.isLocked()) }))
+		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("HasPushed : %v", m.hasPushed) }))
+		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("HasPoped : %v", m.hasPoped) }))
+		Glob.PrintDebug(
+			"UX",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf(
+					"m.beginCount: %v - m.beginLock : %v",
+					m.beginCount,
+					m.beginLock)
+			}),
+		)
+		Glob.PrintDebug(
+			"UX",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf(
+					"m.TopLevelCount: %v - m.TopLevelTot : %v",
+					m.topLevelCount,
+					m.topLevelTot)
+			}),
+		)
+		Glob.PrintDebug(
+			"UX",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Cursor: %v/%v", m.q, m.terms.Len()) }),
+		)
+		Glob.PrintDebug(
+			"UX",
+			Lib.MkLazy(func() string { return fmt.Sprintf("m.terms[cursor] : %v", m.terms.At(m.q).ToString()) }),
+		)
+		Glob.PrintDebug(
+			"UX",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf(
+					"m.terms : %v",
+					m.terms.ToString(AST.Term.ToString, ",", "{}"))
+			}),
+		)
 
 		switch instr := instr.(type) {
 		case Begin:
@@ -144,7 +178,6 @@ func (m *Machine) unifyAux(node Node) []MatchingSubstitutions {
 	matching := []MatchingSubstitutions{}
 
 	if node.isLeaf() {
-		// Glob.PrintDebug("UX", fmt.Sprintf("Is leaf : %v", node.formulae.ToString()))
 		for _, f := range node.formulae.Slice() {
 			if reflect.TypeOf(f) == reflect.TypeOf(AST.Pred{}) || reflect.TypeOf(f) == reflect.TypeOf(TermForm{}) {
 				// Rebuild final substitution between meta and subst
@@ -162,17 +195,23 @@ func (m *Machine) unifyAux(node Node) []MatchingSubstitutions {
 /* Unify on goroutines - to manage die message */
 /* TODO : remove when debug ok */
 func (m *Machine) unifyAuxOnGoroutine(n Node, ch chan []MatchingSubstitutions, father_id uint64) {
-	Glob.PrintDebug("UA", fmt.Sprintf("Child of %v, Unify Aux", father_id))
+	Glob.PrintDebug(
+		"UA",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Child of %v, Unify Aux", father_id) }),
+	)
 	subs := m.unifyAux(n)
 	ch <- subs
-	Glob.PrintDebug("UA", "Die")
+	Glob.PrintDebug("UA", Lib.MkLazy(func() string { return "Die" }))
 }
 
 /* Launches each child of the current node in a goroutine. */
 func (m *Machine) launchChildrenSearch(node Node) []MatchingSubstitutions {
 	channels := []chan []MatchingSubstitutions{}
 	for _, c := range node.children {
-		Glob.PrintDebug("LCS", fmt.Sprintf("Next symbol = %v", c.getValue()[0].ToString()))
+		Glob.PrintDebug(
+			"LCS",
+			Lib.MkLazy(func() string { return fmt.Sprintf("Next symbol = %v", c.getValue()[0].ToString()) }),
+		)
 		channels = append(channels, make(chan []MatchingSubstitutions))
 	}
 
@@ -223,9 +262,7 @@ func (m *Machine) end(instrTerm AST.Term) Status {
 
 /* Algorithm for the instruction Right. */
 func (m *Machine) right() Status {
-	//Glob.PrintDebug("RIGHT", "RIGHT")
 	if m.isUnlocked() {
-		// Glob.PrintDebug("RIGHT", "IS UNLOCKED")
 		m.q += 1
 		if m.q > m.terms.Len() {
 			return Status(ERROR)

--- a/src/Unif/matching_substitutions.go
+++ b/src/Unif/matching_substitutions.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/GoelandProver/Goeland/AST"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 )
 
 type MatchingSubstitutions struct {
@@ -60,7 +61,7 @@ func (m MatchingSubstitutions) ToString() string {
 }
 
 func (m MatchingSubstitutions) Print() {
-	Glob.PrintDebug("M.P", fmt.Sprintf(" %s ", m.GetForm().ToString()))
+	Glob.PrintDebug("M.P", Lib.MkLazy(func() string { return fmt.Sprintf(" %s ", m.GetForm().ToString()) }))
 	m.GetSubst().Print()
 }
 

--- a/src/Unif/substitutions_tree.go
+++ b/src/Unif/substitutions_tree.go
@@ -51,7 +51,14 @@ import (
 * Merge both of them
 **/
 func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.Form) Substitutions {
-	Glob.PrintDebug("CS", fmt.Sprintf("Compute substitution : %v and %v", SubstPairListToString(subs), metasToSubs.ToString()))
+	Glob.PrintDebug(
+		"CS",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Compute substitution : %v and %v",
+				SubstPairListToString(subs), metasToSubs.ToString())
+		}),
+	)
 	metasFromTreeForm := Lib.NewList[AST.Meta]()
 	treeSubs := Substitutions{}
 
@@ -69,7 +76,15 @@ func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.
 	for _, value := range subs {
 		currentMeta := metasFromTreeForm.At(value.GetIndex())
 		currentValue := value.GetTerm()
-		Glob.PrintDebug("CS", fmt.Sprintf("Iterate on subst : %v and  %v", currentMeta.ToString(), currentValue.ToString()))
+		Glob.PrintDebug(
+			"CS",
+			Lib.MkLazy(func() string {
+				return fmt.Sprintf(
+					"Iterate on subst : %v and  %v",
+					currentMeta.ToString(),
+					currentValue.ToString())
+			}),
+		)
 
 		if !currentMeta.Equals(currentValue) {
 			// Si current_meta a déjà une association dans metas
@@ -90,41 +105,61 @@ func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.
 		}
 	}
 
-	Glob.PrintDebug("CS", fmt.Sprintf("before meta : %v", metasToSubs.ToString()))
+	Glob.PrintDebug(
+		"CS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("before meta : %v", metasToSubs.ToString()) }),
+	)
 	// Metas_subst eliminate
 	EliminateMeta(&metasToSubs)
 	Eliminate(&metasToSubs)
 	if metasToSubs.Equals(Failure()) {
 		return Failure()
 	}
-	Glob.PrintDebug("CS", fmt.Sprintf("After meta : %v", metasToSubs.ToString()))
+	Glob.PrintDebug(
+		"CS", Lib.MkLazy(func() string { return fmt.Sprintf("After meta : %v", metasToSubs.ToString()) }),
+	)
 
-	Glob.PrintDebug("CS", fmt.Sprintf("before tree_subst : %v", treeSubs.ToString()))
+	Glob.PrintDebug(
+		"CS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("before tree_subst : %v", treeSubs.ToString()) }),
+	)
 	// Tree subst elminate
 	EliminateMeta(&treeSubs)
 	Eliminate(&treeSubs)
 	if treeSubs.Equals(Failure()) {
 		return Failure()
 	}
-	Glob.PrintDebug("CS", fmt.Sprintf("after tree_subst : %v", treeSubs.ToString()))
+	Glob.PrintDebug(
+		"CS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("after tree_subst : %v", treeSubs.ToString()) }),
+	)
 
 	// Fusion
 	res, _ := MergeSubstitutions(metasToSubs, treeSubs)
 	if res.Equals(Failure()) {
 		return res
 	}
-	Glob.PrintDebug("CS", fmt.Sprintf("after merge : %v", res.ToString()))
+	Glob.PrintDebug(
+		"CS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("after merge : %v", res.ToString()) }),
+	)
 
 	EliminateMeta(&res)
 	Eliminate(&res)
-	Glob.PrintDebug("CS", fmt.Sprintf("after eliminate : %v", res.ToString()))
+	Glob.PrintDebug(
+		"CS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("after eliminate : %v", res.ToString()) }),
+	)
 
 	return res
 }
 
 /* Call addUnification and returns a status - modify m.meta */
 func (m *Machine) trySubstituteMeta(i AST.Term, j AST.Term) Status {
-	Glob.PrintDebug("TS", fmt.Sprintf("Try substitute : %v and %v", i.ToString(), j.ToString()))
+	Glob.PrintDebug(
+		"TS",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Try substitute : %v and %v", i.ToString(), j.ToString()) }),
+	)
 	new_meta := AddUnification(i, j, m.meta.Copy())
 	if new_meta.Equals(Failure()) {
 		return Status(ERROR)
@@ -134,7 +169,16 @@ func (m *Machine) trySubstituteMeta(i AST.Term, j AST.Term) Status {
 }
 
 func AddUnification(term1, term2 AST.Term, subst Substitutions) Substitutions {
-	Glob.PrintDebug("AU", fmt.Sprintf("Add unification : %v and %v to %v", term1.ToString(), term2.ToString(), subst.ToString()))
+	Glob.PrintDebug(
+		"AU",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Add unification : %v and %v to %v",
+				term1.ToString(),
+				term2.ToString(),
+				subst.ToString())
+		}),
+	)
 	// unify with ct only if the term already has an unification or if there is 2 fun. Just add it and eliminate otherwise.
 	t1v, _ := subst.Get(term1.ToMeta())
 	t2v, _ := subst.Get(term2.ToMeta())
@@ -168,7 +212,15 @@ func AddUnification(term1, term2 AST.Term, subst Substitutions) Substitutions {
 
 /* Adds the unifications found to the meta substitutions from running the algorithm on term1 and term2. */
 func (m *Machine) addUnifications(term1, term2 AST.Term) Status {
-	Glob.PrintDebug("au", fmt.Sprintf("add unification : %v and %v", term1.ToString(), term2.ToString()))
+	Glob.PrintDebug(
+		"au",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"add unification : %v and %v",
+				term1.ToString(),
+				term2.ToString())
+		}),
+	)
 	meta := tryUnification(term1.Copy(), term2.Copy(), m.meta.Copy()) // Return empty or an array of 1 matching substitution, which is m.meta improved wit (term1, term2)
 
 	if len(meta) == 0 {
@@ -184,7 +236,15 @@ func (m *Machine) addUnifications(term1, term2 AST.Term) Status {
 
 /* Tries to unify term1 with term2, depending on the substitutions already found by the parent unification process. */
 func tryUnification(term1, term2 AST.Term, meta Substitutions) []MatchingSubstitutions {
-	Glob.PrintDebug("TU", fmt.Sprintf("Try unification : %v and %v", term1.ToString(), term2.ToString()))
+	Glob.PrintDebug(
+		"TU",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Try unification : %v and %v",
+				term1.ToString(),
+				term2.ToString())
+		}),
+	)
 	aux := makeMachine()
 	aux.terms = Lib.MkListV(term2)
 	aux.meta = meta
@@ -197,7 +257,15 @@ func tryUnification(term1, term2 AST.Term, meta Substitutions) []MatchingSubstit
 
 /* Merge two valid substitutions */
 func MergeSubstitutions(s1, s2 Substitutions) (Substitutions, bool) {
-	Glob.PrintDebug("MS", fmt.Sprintf("Merge substitution : %v and %v", s1.ToString(), s2.ToString()))
+	Glob.PrintDebug(
+		"MS",
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf(
+				"Merge substitution : %v and %v",
+				s1.ToString(),
+				s2.ToString())
+		}),
+	)
 	res := Substitutions{}
 	same_key := false
 

--- a/src/Unif/substitutions_type.go
+++ b/src/Unif/substitutions_type.go
@@ -61,7 +61,10 @@ func (s Substitutions) ToStringForProof() string {
 
 /* Helper function, prints the content of a Substitutions object. */
 func (s Substitutions) Print() {
-	Glob.PrintDebug("Print", fmt.Sprintf("Success. %v ", s.ToString()))
+	Glob.PrintDebug(
+		"Print",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Success. %v ", s.ToString()) }),
+	)
 }
 
 /* Substitution list into string */
@@ -229,27 +232,24 @@ func HasSubst(s Substitutions, m AST.Meta) bool {
 /*** Occur check ***/
 /* An invalid occur-check happens if the same meta-variable as the key is found in the value. */
 func OccurCheckValid(key AST.Meta, val AST.Term) bool {
-	// Glob.PrintDebug("OC", fmt.Sprintf("Occur-chek between %v and %v", key.ToString(), val.ToString()))
 	if val.IsFun() && isRecursive(val, key) || key.Equals(val) {
-		// Glob.PrintDebug("OC", "OC FAIL")
 		return false
 	}
-	// Glob.PrintDebug("OC", "OC SUCCESS")
 	return true
 }
 
 /* Checks if the substitution is of type (X, f(X)). */
 func isRecursive(t AST.Term, m AST.Meta) bool {
-	// Glob.PrintDebug("IR", fmt.Sprintf("IR between %v and %v", t.ToString(), m.ToString()))
 	switch t := t.(type) {
 	case AST.Fun:
-		// Glob.PrintDebug("IR", "IR FUN")
 		return areFuncArgsRecursive(t, m)
 	case AST.Meta:
-		// Glob.PrintDebug("IR", "IR META")
 		return t.Equals(m)
 	default:
-		Glob.PrintDebug("IR", "Error: [[substitution.go:157]] shouldn't be attained.")
+		Glob.PrintDebug(
+			"IR",
+			Lib.MkLazy(func() string { return "Error: [[substitution.go:157]] shouldn't be attained." }),
+		)
 	}
 
 	return false
@@ -257,7 +257,6 @@ func isRecursive(t AST.Term, m AST.Meta) bool {
 
 /* Checks if any argument of the function f contains the metavariable m. */
 func areFuncArgsRecursive(f AST.Fun, m AST.Meta) bool {
-	// Glob.PrintDebug("AFAR", fmt.Sprintf("AFAR between %v and %v", f.ToString(), m.ToString()))
 	for _, term := range f.GetArgs().GetSlice() {
 		if isRecursive(term, m) {
 			return true
@@ -269,7 +268,6 @@ func areFuncArgsRecursive(f AST.Fun, m AST.Meta) bool {
 /*** Eliminate ***/
 /* Eliminate - apply each element of the subst on the entire substitution, because an element can't œappears on the rigth and and the left if a substitution */
 func Eliminate(s *Substitutions) {
-	// Glob.PrintDebug("EL", fmt.Sprintf("Eliminate on %v", s.ToString()))
 	if s.Equals(Failure()) {
 		return
 	}
@@ -385,7 +383,10 @@ func eliminateList(
 
 /* Eliminates one of the subsitution of a pair like (X, Y) (Y, X). It will keep the first one indexed in the map. */
 func EliminateMeta(subst *Substitutions) {
-	Glob.PrintDebug("EM", fmt.Sprintf("Eliminate Meta on %v", subst.ToString()))
+	Glob.PrintDebug(
+		"EM",
+		Lib.MkLazy(func() string { return fmt.Sprintf("Eliminate Meta on %v", subst.ToString()) }),
+	)
 	meta := Substitutions{}
 
 	for _, t := range *subst {

--- a/src/main.go
+++ b/src/main.go
@@ -50,6 +50,7 @@ import (
 	"github.com/GoelandProver/Goeland/AST"
 	"github.com/GoelandProver/Goeland/Core"
 	"github.com/GoelandProver/Goeland/Glob"
+	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Mods/assisted"
 	"github.com/GoelandProver/Goeland/Mods/dmt"
 	"github.com/GoelandProver/Goeland/Parser"
@@ -94,7 +95,7 @@ func main() {
 
 // Start solving
 func startSearch(form AST.Form, bound int) {
-	Glob.PrintDebug(main_label, "Start search")
+	Glob.PrintDebug(main_label, Lib.MkLazy(func() string { return "Start search" }))
 
 	// FIXME: assisted should be a plugin.
 	// Ideally, we should create a hook here in order to let plugins do what
@@ -125,7 +126,10 @@ func presearchLoader() (AST.Form, int) {
 
 	statements, bound, containsEquality := Parser.ParseTPTPFile(problem)
 
-	Glob.PrintDebug(main_label, fmt.Sprintf("Statement : %s", Core.StatementListToString(statements)))
+	Glob.PrintDebug(
+		main_label,
+		Lib.MkLazy(func() string { return fmt.Sprintf("Statement : %s", Core.StatementListToString(statements)) }),
+	)
 
 	if Glob.GetLimit() != -1 {
 		bound = Glob.GetLimit()
@@ -183,7 +187,10 @@ func StatementListToFormula(statements []Core.Statement, old_bound int, problemD
 			file_name := statement.GetName()
 
 			realname, err := getFile(file_name, problemDir)
-			Glob.PrintDebug(main_label, fmt.Sprintf("File to parse : %s\n", realname))
+			Glob.PrintDebug(
+				main_label,
+				Lib.MkLazy(func() string { return fmt.Sprintf("File to parse : %s\n", realname) }),
+			)
 
 			if err != nil {
 				Glob.PrintError(main_label, err.Error())


### PR DESCRIPTION
When benching, I've found out that we had 2 major bottlenecks: creation of pointers and calls to the `ToString()` function. I found it strange that the `ToString` was such a problem, but I realized that the `PrintDebug` (and its arguments) were always evaluated, even when `-debug` was not given to the program.

To solve this problem, I've introduced a `Lazy` interface in the `Lib` folder, and used it for `PrintDebug`.
It should significantly boost the number of problems we pass. For instance, on my machine, `SYN007+1.014.p` passes consistently in ~75s when limiting the memory of the program. I expect even better speedups on the bench machine.