### PR TITLE
Fix axiom file not found when not in Goéland's folder

### DIFF
--- a/devtools/test-suite/bugs/Axioms/bug_41-1.ax
+++ b/devtools/test-suite/bugs/Axioms/bug_41-1.ax
@@ -1,0 +1,1 @@
+fof(test_include,axiom,p).

--- a/devtools/test-suite/bugs/bug_41-1.p
+++ b/devtools/test-suite/bugs/bug_41-1.p
@@ -1,0 +1,5 @@
+% result: VALID
+
+include('Axioms/bug_41-1.ax').
+
+fof(prove_this,conjecture,p).

--- a/devtools/test-suite/bugs/bug_41-2.p
+++ b/devtools/test-suite/bugs/bug_41-2.p
@@ -1,0 +1,6 @@
+% env: TPTP=$(PWD)/test-suite/tptp_bugs_env
+% result: VALID
+
+include('bug_41-2.ax').
+
+fof(prove_this,conjecture,p).

--- a/devtools/test-suite/tptp_bugs_env/bug_41-2.ax
+++ b/devtools/test-suite/tptp_bugs_env/bug_41-2.ax
@@ -1,0 +1,1 @@
+fof(test_include,axiom,p).

--- a/src/main.go
+++ b/src/main.go
@@ -282,27 +282,27 @@ func doTypeStatement(statement Core.Statement) {
 }
 
 func getFile(filename string, dir string) (string, error) {
+	fileExists := func(err error) bool {
+		return err == nil && !errors.Is(err, os.ErrNotExist)
+	}
 	// Check in Goéland's path
 	_, err := os.Stat(filename)
-	fileExists := !(err != nil && errors.Is(err, os.ErrNotExist))
-	if fileExists {
+	if fileExists(err) {
 		return filename, err
 	}
 
 	// Check in the dir's path
 	otherFilename := path.Join(dir, filename)
-	_, err = os.Stat(filename)
-	fileExists = !(err != nil && errors.Is(err, os.ErrNotExist))
-	if fileExists {
+	_, err = os.Stat(otherFilename)
+	if fileExists(err) {
 		return otherFilename, err
 	}
 
 	// Check in the environment variable
 	directory := os.Getenv("TPTP")
 	otherFilename = path.Join(directory, filename)
-	_, err = os.Stat(filename)
-	fileExists = !(err != nil && errors.Is(err, os.ErrNotExist))
-	if fileExists {
+	_, err = os.Stat(otherFilename)
+	if fileExists(err) {
 		return otherFilename, err
 	}
 


### PR DESCRIPTION
Fixes/closes: #41 

# Test-suite update

* Added file `test-suite/bugs/bug_41-1.p` testing an include from the folder `test-suite/bugs/Axioms`
* Added file `test-suite/bugs/bug_41-2.p` testing an include from the TPTP environment variable
* Updated `run-test-suite.py` to parse environment variables, with the special variable `$(PWD)`
* Updated `run-test-suite.py` to report unknown failures.