### PR TITLE
CI: use go install instead of distribution-based package to get goyacc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '>=1.22.0'
-      - run: sudo apt-get install -y golang-golang-x-tools
+      - run: go install golang.org/x/tools/cmd/goyacc@latest
       - run: cd src && make

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '>=1.22.0'
-      - run: sudo apt-get install -y golang-golang-x-tools
+      - run: go install golang.org/x/tools/cmd/goyacc@latest
       - run: cd src && make && make tests
 
   VanillaSoundness:
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}
-      - run: sudo apt-get install -y golang-golang-x-tools
+      - run: go install golang.org/x/tools/cmd/goyacc@latest
       - run: cd src && make
       - run: cd devtools && python3 run_soundness_tests.py ../.github/soundness 120
 
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}
-      - run: sudo apt-get install -y golang-golang-x-tools
+      - run: go install golang.org/x/tools/cmd/goyacc@latest
       - run: cd src && make
       - run: cd devtools && python3 run_soundness_tests.py ../.github/soundness 120 -inner
 
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}
-      - run: sudo apt-get install -y golang-golang-x-tools
+      - run: go install golang.org/x/tools/cmd/goyacc@latest
       - run: cd src && make
       - run: cd devtools && python3 run_soundness_tests.py ../.github/soundness 120 -preinner
 
@@ -80,7 +80,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}
-      - run: sudo apt-get install -y golang-golang-x-tools
+      - run: go install golang.org/x/tools/cmd/goyacc@latest
       - run: cd src && make
       - run: cd devtools && python3 run_soundness_tests.py ../.github/soundness 120 -dmt
 
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}
-      - run: sudo apt-get install -y golang-golang-x-tools
+      - run: go install golang.org/x/tools/cmd/goyacc@latest
       - run: cd src && make
       - run: cd devtools && make test-suite
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ It supports [TPTP](http://tptp.org/) FOF and TFF files.
 
 In order to compile, Goéland needs:
 * Go (version >= 1.22, download directly from the [site](https://go.dev/)), and
-* `goyacc`, which can be found
+* `goyacc`, which can be installed (recommended) from `go`'s package manager tool using:
+  ```
+  go install golang.org/x/tools/cmd/goyacc
+  ```
+  or can be found in distribution-based packages:
   - in the package `golang-golang-x-tools` on `apt`-based distributions,
   - in the package `goyacc` with homebrew.
 


### PR DESCRIPTION
Fixes the build step failing in the CI