### PR TITLE
Debuggers for a more fine-grained debug output

### DIFF
--- a/src/AST/maker.go
+++ b/src/AST/maker.go
@@ -39,6 +39,7 @@ package AST
 import (
 	"sync"
 
+	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 )
 
@@ -51,6 +52,12 @@ var idVar map[string]int = make(map[string]int)
 var occurenceMeta map[string]int = make(map[string]int)
 var lock_term sync.Mutex
 var lock_formula sync.Mutex
+
+var debug Glob.Debugger
+
+func InitDebugger() {
+	debug = Glob.CreateDebugger("AST")
+}
 
 // Global id
 var Id_eq Id

--- a/src/AST/typearrow.go
+++ b/src/AST/typearrow.go
@@ -108,10 +108,7 @@ func (ta TypeArrow) GetPrimitives() []TypeApp {
 /* Makes a TypeArrow from two TypeSchemes */
 func MkTypeArrow(left TypeApp, typeApps ...TypeApp) TypeArrow {
 	if len(typeApps) < 1 {
-		Glob.PrintDebug(
-			"MKTA",
-			Lib.MkLazy(func() string { return "There should be at least one out type in a TypeArrow." }),
-		)
+		debug(Lib.MkLazy(func() string { return "There should be at least one out type in a TypeArrow." }))
 		return TypeArrow{}
 	}
 	ta := TypeArrow{left: left, right: make(Lib.ComparableList[TypeApp], len(typeApps))}

--- a/src/AST/typecross.go
+++ b/src/AST/typecross.go
@@ -120,10 +120,7 @@ func (tc TypeCross) GetAllUnderlyingTypes() []TypeApp {
  **/
 func MkTypeCross(typeSchemes ...TypeApp) TypeCross {
 	if len(typeSchemes) < 2 {
-		Glob.PrintDebug(
-			"MKTC",
-			Lib.MkLazy(func() string { return "There should be at least two underlying types in a TypeCross." }),
-		)
+		debug(Lib.MkLazy(func() string { return "There should be at least two underlying types in a TypeCross." }))
 		return TypeCross{}
 	}
 	tc := TypeCross{types: make([]TypeApp, len(typeSchemes))}

--- a/src/Core/FormListDS.go
+++ b/src/Core/FormListDS.go
@@ -33,7 +33,6 @@ package Core
 
 import (
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Unif"
 )
@@ -71,7 +70,7 @@ func (f FormListDS) InsertFormulaListToDataStructure(lf *AST.FormList) Unif.Data
 
 func (f FormListDS) Print() {
 	for _, f := range f.GetFL().Slice() {
-		Glob.PrintDebug("FLTS", Lib.MkLazy(func() string { return f.ToString() }))
+		debug(Lib.MkLazy(func() string { return f.ToString() }))
 	}
 }
 

--- a/src/Core/form_and_terms_list.go
+++ b/src/Core/form_and_terms_list.go
@@ -41,7 +41,6 @@ import (
 	"sort"
 
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 )
 
@@ -85,7 +84,7 @@ func (fl FormAndTermsList) ToString() string {
 /* Print a list of formulas */
 func (lf FormAndTermsList) Print() {
 	for _, f := range lf {
-		Glob.PrintDebug("FLTS", Lib.MkLazy(func() string { return f.GetForm().ToString() }))
+		debug(Lib.MkLazy(func() string { return f.GetForm().ToString() }))
 	}
 }
 

--- a/src/Core/global_unifier.go
+++ b/src/Core/global_unifier.go
@@ -133,7 +133,7 @@ func (u Unifier) GetUnifier() Unif.Substitutions {
 	if !Glob.GetProof() || len(u.localUnifiers) == 0 {
 		return Unif.MakeEmptySubstitution()
 	}
-	Glob.PrintDebug("UNIFS", Lib.MkLazy(func() string { return u.ToString() }))
+	debug(Lib.MkLazy(func() string { return u.ToString() }))
 	if len(u.localUnifiers) > 0 && len(u.localUnifiers[0].Snd) > 0 {
 		return u.localUnifiers[0].Snd[0]
 	}
@@ -162,8 +162,7 @@ func (u *Unifier) Merge(other Unifier) {
 		return
 	}
 
-	Glob.PrintDebug(
-		"GLOBAL UNIFIER",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Current: %s, to merge: %s", u.ToString(), other.ToString()) }),
 	)
 
@@ -194,7 +193,7 @@ func (u *Unifier) Merge(other Unifier) {
 		}
 	}
 	u.localUnifiers = newUnifiers
-	Glob.PrintDebug("GLOBAL UNIFIER", Lib.MkLazy(func() string { return fmt.Sprintf("After: %s", u.ToString()) }))
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf("After: %s", u.ToString()) }))
 }
 
 func (u *Unifier) PruneMetasInSubsts(metas Lib.Set[AST.Meta]) {

--- a/src/Core/meta_gen.go
+++ b/src/Core/meta_gen.go
@@ -134,8 +134,7 @@ func getAllLessReintroducedMeta(meta_generator []MetaGen, allowed_indexes []int)
 	min := -1
 	saved_indexes := []int{}
 	for i, v := range meta_generator {
-		Glob.PrintDebug(
-			"PS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("v.getCounter : %d - Min : %d", v.GetCounter(), min) }),
 		)
 		if (allowed_indexes == nil || Glob.ContainsInt(i, allowed_indexes)) && ((v.GetCounter() <= min) || min == -1) {
@@ -147,7 +146,7 @@ func getAllLessReintroducedMeta(meta_generator []MetaGen, allowed_indexes []int)
 				saved_indexes = Glob.AppendIfNotContainsInt(saved_indexes, i)
 			}
 		}
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("Min after : %d", min) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("Min after : %d", min) }))
 	}
 	return saved_indexes
 }
@@ -172,8 +171,7 @@ func ReintroduceMeta(meta_generator *[]MetaGen, index int, limit int) FormAndTer
 /* reintroduce the given meta iff is it part of the less reintroduced ones */
 func ReintroduceMetaIfLessReintroduced(meta_generator *[]MetaGen, index int) FormAndTerms {
 	indexes_less_reintroduced_meta := getAllLessReintroducedMeta(*meta_generator, nil)
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Less reintroduced metas : %s",

--- a/src/Core/statement.go
+++ b/src/Core/statement.go
@@ -34,8 +34,15 @@ package Core
 
 import (
 	"github.com/GoelandProver/Goeland/AST"
+	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 )
+
+var debug Glob.Debugger
+
+func InitDebugger() {
+	debug = Glob.CreateDebugger("core")
+}
 
 /***************************/
 /* Structure of statements */

--- a/src/Core/substitutions_search.go
+++ b/src/Core/substitutions_search.go
@@ -66,7 +66,7 @@ func GetMetaFromSubst(subs Unif.Substitutions) Lib.Set[AST.Meta] {
 
 /* Remove substitution without mm */
 func RemoveElementWithoutMM(subs Unif.Substitutions, mm Lib.Set[AST.Meta]) Unif.Substitutions {
-	Glob.PrintDebug("REWM", Lib.MkLazy(func() string {
+	debug(Lib.MkLazy(func() string {
 		return fmt.Sprintf(
 			"MM : %v",
 			Lib.ListToString(mm.Elements(), ",", "[]"),
@@ -81,7 +81,7 @@ func RemoveElementWithoutMM(subs Unif.Substitutions, mm Lib.Set[AST.Meta]) Unif.
 
 	for hasChanged {
 		hasChanged = false
-		Glob.PrintDebug("REWM", Lib.MkLazy(func() string {
+		debug(Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Relevant meta : %v",
 				Lib.ListToString(relevantMetas.Elements(), ",", "[]"),
@@ -116,12 +116,10 @@ func RemoveElementWithoutMM(subs Unif.Substitutions, mm Lib.Set[AST.Meta]) Unif.
 		}
 	}
 
-	Glob.PrintDebug(
-		"REWM",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Subst intermédiaire res : %v", res.ToString()) }),
 	)
-	Glob.PrintDebug(
-		"REWM",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Subst intermédiaire subst_to_reorganize  : %v",
@@ -134,8 +132,7 @@ func RemoveElementWithoutMM(subs Unif.Substitutions, mm Lib.Set[AST.Meta]) Unif.
 	Unif.Eliminate(&subsToReorganize)
 	ms, _ := Unif.MergeSubstitutions(res, subsToReorganize)
 
-	Glob.PrintDebug(
-		"REWM",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Finale subst : %v", ms.ToString()) }),
 	)
 

--- a/src/Glob/helper.go
+++ b/src/Glob/helper.go
@@ -39,6 +39,7 @@ package Glob
 import (
 	"bytes"
 	"fmt"
+	"github.com/GoelandProver/Goeland/Lib"
 	"os"
 	"runtime"
 	"strconv"
@@ -83,7 +84,7 @@ var type_check = true
 
 var IncrEq = false
 
-var debug = false
+var debug = Lib.EmptySet[Lib.String]()
 var writeLogs = false
 var silent = false
 
@@ -126,7 +127,7 @@ func GetGID() uint64 {
 
 /* Getters */
 func GetDebug() bool {
-	return debug
+	return !debug.IsEmpty()
 }
 
 func GetSilent() bool {
@@ -282,8 +283,25 @@ func NoTypeCheck() bool {
 }
 
 /* Setters */
-func SetDebug(b bool) {
-	debug = b
+func SetDebug(debug_list string) {
+	if debug_list == "none" {
+		return
+	}
+
+	EnableDebug()
+
+	if debug_list == "" || debug_list == "all" {
+		debug = registered_debuggers
+	} else {
+		for _, s := range strings.Split(debug_list, ",") {
+			str := Lib.MkString(s)
+			if !registered_debuggers.Contains(str) {
+				PrintWarn("debug", fmt.Sprintf("Undefined debugger %s", s))
+			} else {
+				debug = debug.Add(str)
+			}
+		}
+	}
 }
 
 func SetSilent(b bool) {

--- a/src/Glob/log.go
+++ b/src/Glob/log.go
@@ -78,9 +78,9 @@ func InitLogs() {
 	registered_debuggers = Lib.EmptySet[Lib.String]()
 }
 
-/* Sets the function to be called when PrintDebug is called. This way, we avoid an if test when not in debug mode. */
+/* Sets the function to be called when printDebug is called. This way, we avoid an if test when not in debug mode. */
 func EnableDebug() {
-	PrintDebug = func(function string, message Lib.Lazy[string]) {
+	printDebug = func(function string, message Lib.Lazy[string]) {
 		printToLogger(logDebug, function, message.Run())
 	}
 
@@ -155,7 +155,7 @@ func EnableWriteLogs() {
 // Use when you want to display a message for debugging purposes only.
 // The prefix for debug messages is '[debug]' in blue.
 // Will only print in the terminal and/or the file if the corresponding options -debug and -dif have been set.
-var PrintDebug = func(function string, message Lib.Lazy[string]) {}
+var printDebug = func(function string, message Lib.Lazy[string]) {}
 
 // Prints the message into the terminal and the file as an information message
 //
@@ -189,7 +189,7 @@ func CreateDebugger(name string) Debugger {
 			if ok {
 				displayed_name = fmt.Sprintf("%s:%s:%d", name, filepath.Base(file), no)
 			}
-			PrintDebug(displayed_name, s)
+			printDebug(displayed_name, s)
 		}
 	}
 	return debug

--- a/src/Glob/log.go
+++ b/src/Glob/log.go
@@ -48,8 +48,6 @@ var (
 	logDebug   *log.Logger
 	logInfo    *log.Logger
 	logError   *log.Logger
-	logPanic   *log.Logger
-	logFatal   *log.Logger
 	logWarning *log.Logger
 
 	wrt      io.Writer
@@ -116,8 +114,7 @@ func EnableShowTrace() {
 	logDebug.SetFlags(log.Lshortfile)
 	logInfo.SetFlags(log.Lshortfile)
 	logError.SetFlags(log.Lshortfile)
-	logPanic.SetFlags(log.Lshortfile)
-	logFatal.SetFlags(log.Lshortfile)
+	logWarning.SetFlags(log.Lshortfile)
 }
 
 func EnableLogFile(file string) {
@@ -144,8 +141,7 @@ func EnableWriteLogs() {
 	logDebug.SetOutput(wrt)
 	logInfo.SetOutput(wrt)
 	logError.SetOutput(wrt)
-	logPanic.SetOutput(wrt)
-	logFatal.SetOutput(wrt)
+	logWarning.SetOutput(wrt)
 }
 
 // Prints the message into the terminal and/or the file as a debug message

--- a/src/Lib/string.go
+++ b/src/Lib/string.go
@@ -1,0 +1,60 @@
+/**
+* Copyright 2022 by the authors (see AUTHORS).
+*
+* Goéland is an automated theorem prover for first order logic.
+*
+* This software is governed by the CeCILL license under French law and
+* abiding by the rules of distribution of free software.  You can  use,
+* modify and/ or redistribute the software under the terms of the CeCILL
+* license as circulated by CEA, CNRS and INRIA at the following URL
+* "http://www.cecill.info".
+*
+* As a counterpart to the access to the source code and  rights to copy,
+* modify and redistribute granted by the license, users are provided only
+* with a limited warranty  and the software's author,  the holder of the
+* economic rights,  and the successive licensors  have only  limited
+* liability.
+*
+* In this respect, the user's attention is drawn to the risks associated
+* with loading,  using,  modifying and/or developing or reproducing the
+* software by the user in light of its specific status of free software,
+* that may mean  that it is complicated to manipulate,  and  that  also
+* therefore means  that it is reserved for developers  and  experienced
+* professionals having in-depth computer knowledge. Users are therefore
+* encouraged to load and test the software's suitability as regards their
+* requirements in conditions enabling the security of their systems and/or
+* data to be ensured and,  more generally, to use and operate it in the
+* same conditions as regards security.
+*
+* The fact that you are presently reading this means that you have had
+* knowledge of the CeCILL license and that you accept its terms.
+**/
+
+/**
+ * This file offers [String], a wrapper around [string] that allows for writing
+ * methods over strings.
+ **/
+
+package Lib
+
+type String struct {
+	value string
+}
+
+func (s String) Equals(oth any) bool {
+	if str, ok := oth.(String); ok {
+		return s.value == str.value
+	}
+	return false
+}
+
+func (s String) Less(oth any) bool {
+	if str, ok := oth.(String); ok {
+		return s.value < str.value
+	}
+	return false
+}
+
+func MkString(s string) String {
+	return String{s}
+}

--- a/src/Mods/assisted/assistant.go
+++ b/src/Mods/assisted/assistant.go
@@ -42,6 +42,12 @@ import (
 	"github.com/GoelandProver/Goeland/Unif"
 )
 
+var debug Glob.Debugger
+
+func InitDebugger() {
+	debug = Glob.CreateDebugger("plugin.assisted")
+}
+
 var ruleSynonymList = map[string]string{
 	"Atomic": "X",
 	"atomic": "X",

--- a/src/Mods/assisted/rules.go
+++ b/src/Mods/assisted/rules.go
@@ -75,8 +75,7 @@ func applyAtomicRule(state Search.State, fatherId uint64, c Search.Communication
 	listSubsts := [][]Core.SubstAndForm{}
 	finalBool := true
 	for _, f := range state.GetAtomic() {
-		Glob.PrintDebug(
-			"Assisted",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("##### Formula %v #####", f.ToString()) }),
 		)
 
@@ -92,8 +91,7 @@ func applyAtomicRule(state Search.State, fatherId uint64, c Search.Communication
 	}
 
 	if !foundOne {
-		Glob.PrintDebug(
-			"ApplyAtomicRule",
+		debug(
 			Lib.MkLazy(func() string {
 				return "No valid substitution found. This state will be copied and put back in the list."
 			}),
@@ -120,10 +118,9 @@ func applyAtomicRule(state Search.State, fatherId uint64, c Search.Communication
 }
 
 func applyAlphaRule(state Search.State, indiceForm int, fatherId uint64, c Search.Communication, substitut Core.SubstAndForm, originalNodeId int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "User chose Alpha rule" }))
+	debug(Lib.MkLazy(func() string { return "User chose Alpha rule" }))
 	hdf := state.GetAlpha()[indiceForm]
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }),
 	)
 
@@ -141,9 +138,9 @@ func applyAlphaRule(state Search.State, indiceForm int, fatherId uint64, c Searc
 }
 
 func applyBetaRule(state Search.State, substitut Core.SubstAndForm, c Search.Communication, fatherId uint64, nodeId int, originalNodeId int, metaToReintroduce []int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "User chose Beta rule" }))
+	debug(Lib.MkLazy(func() string { return "User chose Beta rule" }))
 	hdf := state.GetBeta()[0]
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
 	reslf := Search.ApplyBetaRules(hdf, &state)
 	child_id_list := []int{}
 
@@ -177,7 +174,7 @@ func applyBetaRule(state Search.State, substitut Core.SubstAndForm, c Search.Com
 		}
 
 		Glob.IncrGoRoutine(1)
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("GO %v !", fl.GetI()) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("GO %v !", fl.GetI()) }))
 
 	}
 
@@ -185,10 +182,9 @@ func applyBetaRule(state Search.State, substitut Core.SubstAndForm, c Search.Com
 }
 
 func applyDeltaRule(state Search.State, indiceForm int, fatherId uint64, c Search.Communication, substitut Core.SubstAndForm, originalNodeId int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "User chose Delta rule" }))
+	debug(Lib.MkLazy(func() string { return "User chose Delta rule" }))
 	hdf := state.GetDelta()[indiceForm]
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }),
 	)
 
@@ -206,13 +202,11 @@ func applyDeltaRule(state Search.State, indiceForm int, fatherId uint64, c Searc
 }
 
 func applyGammaRule(state Search.State, indiceForm int, fatherId uint64, c Search.Communication, substitut Core.SubstAndForm, originalNodeId int) {
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return "User chose Gamma rule" }),
 	)
 	hdf := state.GetGamma()[indiceForm]
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }),
 	)
 	state.SetGamma(append(state.GetGamma()[:indiceForm], state.GetGamma()[indiceForm+1:]...))
@@ -240,9 +234,8 @@ func applyGammaRule(state Search.State, indiceForm int, fatherId uint64, c Searc
 }
 
 func applyReintroductionRule(state Search.State, fatherId uint64, c Search.Communication, originalNodeId int, metaToReintroduce []int, chosenReintro int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Reintroduction" }))
-	Glob.PrintDebug(
-		"PS",
+	debug(Lib.MkLazy(func() string { return "Reintroduction" }))
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Meta to reintroduce : %s",
@@ -251,8 +244,7 @@ func applyReintroductionRule(state Search.State, fatherId uint64, c Search.Commu
 	)
 	newMetaGen := state.GetMetaGen()
 	reslf := Core.ReintroduceMeta(&newMetaGen, chosenReintro, state.GetN())
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Reintroduce the formula : %s", reslf.ToString()) }),
 	)
 	state.SetLF(Core.MakeSingleElementFormAndTermList(reslf))

--- a/src/Mods/assisted/status.go
+++ b/src/Mods/assisted/status.go
@@ -36,7 +36,6 @@ import (
 	"sync"
 
 	"github.com/GoelandProver/Goeland/Core"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Search"
 )
@@ -97,8 +96,7 @@ func (se *StatusElement) applySubs(sub Core.SubstAndForm) {
 }
 
 func (se *StatusElement) sendChoice(choice Choice) {
-	Glob.PrintDebug(
-		"ASSISTED",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Choice sent to state nº%d : %v", se.getId(), choice) }),
 	)
 
@@ -107,8 +105,7 @@ func (se *StatusElement) sendChoice(choice Choice) {
 
 func (se *StatusElement) receiveChoice() Choice {
 	choice := <-se.channel
-	Glob.PrintDebug(
-		"ASSISTED",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Choice received from state nº%d : %v", se.getId(), choice) }),
 	)
 	return choice

--- a/src/Mods/dmt/axiom_registration.go
+++ b/src/Mods/dmt/axiom_registration.go
@@ -45,6 +45,12 @@ import (
 	"github.com/GoelandProver/Goeland/Lib"
 )
 
+var debug Glob.Debugger
+
+func InitDebugger() {
+	debug = Glob.CreateDebugger("plugin.DMT")
+}
+
 func RegisterAxiom(axiom AST.Form) bool {
 	axiomFT := instanciateForalls(axiom)
 
@@ -98,8 +104,7 @@ func printDebugRewriteRule(polarity bool, axiom, cons AST.Form) {
 	} else {
 		ax, co = AST.MakerNot(axiom).ToString(), cons.ToString()
 	}
-	Glob.PrintDebug(
-		"DMT",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Rewrite rule: %s ---> %s\n", ax, co) }),
 	)
 }

--- a/src/Mods/equality/bse/constraints_list.go
+++ b/src/Mods/equality/bse/constraints_list.go
@@ -40,7 +40,6 @@ import (
 	"fmt"
 
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Unif"
 )
@@ -89,24 +88,20 @@ func makeEmptyConstaintsList() ConstraintList {
 
 /* Check if a constraint is consistant with LPO and constraint list */
 func (cl ConstraintList) isConsistantWithSubst(s Unif.Substitutions) bool {
-	Glob.PrintDebug(
-		"ICWS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Is consistant with the subst : %v", s.ToString()) }),
 	)
 	for _, c_element := range cl {
 		c := c_element.copy()
-		Glob.PrintDebug(
-			"ICWS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Constraint : %v", c.toString()) }),
 		)
 		c.applySubstitution(s)
-		Glob.PrintDebug(
-			"ICWS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Constraint after apply subst : %v", c.toString()) }),
 		)
 		respect_lpo, is_comparable := c.checkLPO()
-		Glob.PrintDebug(
-			"ICWS",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"Is comparable : %v - respect lpo : %v: ",
@@ -130,7 +125,7 @@ func (cl ConstraintList) checkConstraintList() bool {
 	map_constraintes := make(map[string][]Lib.List[AST.Term])
 
 	for _, c := range cl {
-		Glob.PrintDebug("CCL", Lib.MkLazy(func() string { return fmt.Sprintf("Constraint : %v", c.toString()) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("Constraint : %v", c.toString()) }))
 		switch c.getCType() {
 		case PREC:
 			if !appendToMapAndCheck(c.getTP().GetT1().ToString(), c.getTP().GetT2(), &map_constraintes, 1, 2) {

--- a/src/Mods/equality/bse/constraints_struct.go
+++ b/src/Mods/equality/bse/constraints_struct.go
@@ -39,7 +39,6 @@ package equality
 import (
 	"fmt"
 
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Unif"
 )
@@ -95,22 +94,18 @@ func makeConstraintStruct(ac ConstraintList, s Unif.Substitutions, p ConstraintL
 func (cs *ConstraintStruct) appendIfConsistant(c Constraint) bool {
 	if !cs.getAllConstraints().contains(c) {
 		if is_consistant := cs.isConsistantWith(c); is_consistant {
-			Glob.PrintDebug(
-				"AIC",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("%v is consistant", c.toString()) }),
 			)
-			Glob.PrintDebug(
-				"AIC",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("CL at the end : %v", cs.toString()) }),
 			)
 			return true
 		} else {
-			Glob.PrintDebug(
-				"AIC",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("%v is not consistant", c.toString()) }),
 			)
-			Glob.PrintDebug(
-				"AIC",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("CL at the end : %v", cs.toString()) }),
 			)
 			return false
@@ -121,8 +116,7 @@ func (cs *ConstraintStruct) appendIfConsistant(c Constraint) bool {
 
 /* Check if a constraint is consistant with LPO and constraint list + update cl */
 func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
-	Glob.PrintDebug(
-		"ICW",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Constraint : %v", c.toString()) }),
 	)
 	switch c.getCType() {
@@ -131,8 +125,7 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 		new_c := c.copy()
 		new_c.applySubstitution(cs.getSubst())
 		respect_lpo, is_comparable := new_c.checkLPO()
-		Glob.PrintDebug(
-			"ICW",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"Is_comparable : %v, respec_lpo : %v", is_comparable, respect_lpo)
@@ -155,8 +148,7 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 	case EQ:
 		// Check if the EQ constraint is unifiable
 		subst := Unif.AddUnification(c.getTP().GetT1().Copy(), c.getTP().GetT2().Copy(), Unif.MakeEmptySubstitution())
-		Glob.PrintDebug(
-			"ICW",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Candidate subst : %v", subst.ToString()) }),
 		)
 		if subst.Equals(Unif.Failure()) {
@@ -172,8 +164,7 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 		//	return respect_lpo
 		// }
 
-		Glob.PrintDebug(
-			"ICW",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"Try to check compatibility : %v (%v and %v) and %v",
@@ -186,8 +177,7 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 		)
 		// Add it to subst and check unification consistency
 		subst_all := Unif.AddUnification(c.getTP().GetT1(), c.getTP().GetT2(), cs.getSubst())
-		Glob.PrintDebug(
-			"ICW",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Subst all : %v", subst_all.ToString()) }),
 		)
 		if subst_all.Equals(Unif.Failure()) {
@@ -198,9 +188,9 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 		}
 
 		// Apply new global subst to prec
-		Glob.PrintDebug("ICW", Lib.MkLazy(func() string { return "Check if consistant with the whole cl" }))
+		debug(Lib.MkLazy(func() string { return "Check if consistant with the whole cl" }))
 		if !cs.getPrec().isConsistantWithSubst(subst_all) {
-			Glob.PrintDebug("ICW", Lib.MkLazy(func() string { return "Not consistant with the whole cl" }))
+			debug(Lib.MkLazy(func() string { return "Not consistant with the whole cl" }))
 			return false
 		}
 
@@ -210,7 +200,7 @@ func (cs *ConstraintStruct) isConsistantWith(c Constraint) bool {
 		return true
 
 	default:
-		Glob.PrintDebug("ICW", Lib.MkLazy(func() string { return "Constraint type unknown" }))
+		debug(Lib.MkLazy(func() string { return "Constraint type unknown" }))
 		return false
 	}
 }

--- a/src/Mods/equality/bse/constraints_type.go
+++ b/src/Mods/equality/bse/constraints_type.go
@@ -99,13 +99,11 @@ func (c *Constraint) applySubstitution(s Unif.Substitutions) {
 
 /* return true if the constraint is not violated, false otherwise  + true is the contraint is comparable, false otherwise + update c into the useful part of the constraint */
 func (c *Constraint) checkLPO() (bool, bool) {
-	Glob.PrintDebug(
-		"CLPO",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Type %v, cst : %v", c.getCType(), c.toString()) }),
 	)
 	cs := compareLPO(c.getTP().GetT1(), c.getTP().GetT2())
-	Glob.PrintDebug(
-		"CLPO",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("res : %v, is_comparable : %v", cs.order, cs.is_comparable) }),
 	)
 

--- a/src/Mods/equality/bse/equality.go
+++ b/src/Mods/equality/bse/equality.go
@@ -46,6 +46,12 @@ import (
 	"github.com/GoelandProver/Goeland/Unif"
 )
 
+var debug Glob.Debugger
+
+func InitDebugger() {
+	debug = Glob.CreateDebugger("plugin.equality")
+}
+
 func Enable() {
 	SetTryEquality()
 	eqStruct.NewEqStruct = NewBasicEqualityStruct
@@ -57,9 +63,9 @@ func SetTryEquality() {
 
 func TryEquality(atomics_for_dmt Core.FormAndTermsList, st Search.State, new_atomics Core.FormAndTermsList, father_id uint64, cha Search.Communication, node_id int, original_node_id int) bool {
 	if !Glob.GetDMTBeforeEq() || len(atomics_for_dmt) == 0 || len(st.GetLF()) == 0 {
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Try apply EQ !" }))
+		debug(Lib.MkLazy(func() string { return "Try apply EQ !" }))
 		if len(new_atomics) > 0 || len(st.GetLF()) == 0 {
-			Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "EQ is applicable !" }))
+			debug(Lib.MkLazy(func() string { return "EQ is applicable !" }))
 			atomics_plus_dmt := append(st.GetAtomic(), atomics_for_dmt...)
 			res_eq, subst_eq := EqualityReasoning(st.GetEqStruct(), st.GetTreePos(), st.GetTreeNeg(), atomics_plus_dmt.ExtractForms(), original_node_id)
 			if res_eq {
@@ -89,7 +95,7 @@ func TryEquality(atomics_for_dmt Core.FormAndTermsList, st Search.State, new_ato
 * returns a bool for success and the corresponding substitution
 **/
 func EqualityReasoning(eqStruct eqStruct.EqualityStruct, tree_pos, tree_neg Unif.DataStructure, atomic *AST.FormList, originalNodeId int) (bool, []Unif.Substitutions) {
-	Glob.PrintDebug("ER", Lib.MkLazy(func() string { return "ER call" }))
+	debug(Lib.MkLazy(func() string { return "ER call" }))
 	problem, equalities := buildEqualityProblemMultiList(atomic, tree_pos, tree_neg)
 	if equalities {
 		return RunEqualityReasoning(eqStruct, problem)

--- a/src/Mods/equality/bse/equality_problem_list.go
+++ b/src/Mods/equality/bse/equality_problem_list.go
@@ -45,7 +45,6 @@ import (
 	"strings"
 
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Unif"
 )
@@ -235,8 +234,7 @@ func buildEqualityProblemMultiListFromFormList(fl *AST.FormList, tn Unif.DataStr
 	res := makeEmptyEqualityProblemMultiList()
 	for _, p := range fl.Slice() {
 		if pt, ok := p.(AST.Pred); ok {
-			Glob.PrintDebug(
-				"BEPMLFFL",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("Pred found : %v", p.ToString()) }),
 			)
 			if !pt.GetID().Equals(AST.Id_eq) {
@@ -258,13 +256,11 @@ func buildEqualityProblemMultiList(fl *AST.FormList, tp, tn Unif.DataStructure) 
 		return res, false
 	}
 	res = append(res, buildEqualityProblemMultiListFromNEQ(retrieveInequalities(tn.Copy()), eq.copy())...)
-	Glob.PrintDebug(
-		"BEPML",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Res after FromNEQ : %v", res.ToString()) }),
 	)
 	res = append(res, buildEqualityProblemMultiListFromFormList(fl.Copy(), tn.Copy(), eq.copy())...)
-	Glob.PrintDebug(
-		"BEPML",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Res after FromForm : %v", res.ToString()) }),
 	)
 

--- a/src/Mods/equality/bse/equality_rules_apply.go
+++ b/src/Mods/equality/bse/equality_rules_apply.go
@@ -40,20 +40,17 @@ import (
 	"fmt"
 
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Mods/equality/eqStruct"
 )
 
 /* apply a rule */
 func applyRule(rs ruleStruct, ep EqualityProblem, parent chan answerEP, father_id uint64) {
-	Glob.PrintDebug("EQ-AR", Lib.MkLazy(func() string { return fmt.Sprintf("Child of %v", father_id) }))
-	Glob.PrintDebug(
-		"EQ-AR",
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf("Child of %v", father_id) }))
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("EQ before applying rule %v", ep.ToString()) }),
 	)
-	Glob.PrintDebug(
-		"EQ-AR",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Apply rule %v", rs.toString()) }),
 	)
 	switch rs.getRule() {
@@ -62,8 +59,7 @@ func applyRule(rs ruleStruct, ep EqualityProblem, parent chan answerEP, father_i
 	case RIGHT:
 		applyRightRule(rs, ep, parent, father_id)
 	default:
-		Glob.PrintDebug(
-			"AR",
+		debug(
 			Lib.MkLazy(func() string { return "[EQ] Rule type unknown" }),
 		)
 	}
@@ -71,15 +67,13 @@ func applyRule(rs ruleStruct, ep EqualityProblem, parent chan answerEP, father_i
 
 /* Apply left rigid basic superposition rule */
 func applyLeftRule(rs ruleStruct, ep EqualityProblem, father_chan chan answerEP, father_id uint64) {
-	Glob.PrintDebug(
-		"ALR",
+	debug(
 		Lib.MkLazy(func() string { return "Apply left rule" }),
 	)
 	is_consistant_with_lpo, new_term, new_cl := applyEQRule(rs.getL(), rs.getR(), rs.getLPrime(), rs.getS(), rs.getT(), ep.getC())
 
 	if is_consistant_with_lpo {
-		Glob.PrintDebug(
-			"ALR",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("New term : %v", new_term.ToString()) }),
 		)
 		new_eq_list := ep.GetE()
@@ -88,33 +82,29 @@ func applyLeftRule(rs ruleStruct, ep EqualityProblem, father_chan chan answerEP,
 		} else {
 			new_eq_list[rs.getIndexEQList()] = eqStruct.MakeTermPair(rs.getS(), new_term.Copy())
 		}
-		Glob.PrintDebug(
-			"ALR",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("New EQ list : %v", new_eq_list.ToString()) }),
 		)
 		tryEqualityReasoningProblem(makeEqualityProblem(new_eq_list, ep.GetS(), ep.GetT(), new_cl), father_chan, rs.getIndexEQList(), LEFT, father_id)
 	} else {
-		Glob.PrintDebug(
-			"ALR",
+		debug(
 			Lib.MkLazy(func() string { return "Not consistant with LPO, send nil" }),
 		)
 		father_chan <- makeEmptyAnswerEP()
-		Glob.PrintDebug("ALR", Lib.MkLazy(func() string { return "Die" }))
+		debug(Lib.MkLazy(func() string { return "Die" }))
 	}
 }
 
 /* Apply right rigid basic superposition rule */
 func applyRightRule(rs ruleStruct, ep EqualityProblem, father_chan chan answerEP, father_id uint64) {
-	Glob.PrintDebug(
-		"ARR",
+	debug(
 		Lib.MkLazy(func() string { return "Apply right rule" }),
 	)
 
 	is_consistant_with_lpo, new_term, new_cl := applyEQRule(rs.getL(), rs.getR(), rs.getLPrime(), rs.getS(), rs.getT(), ep.getC())
 
 	if is_consistant_with_lpo {
-		Glob.PrintDebug(
-			"ARR",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("New term : %v", new_term.ToString()) }),
 		)
 		if rs.getIsSModified() {
@@ -123,12 +113,11 @@ func applyRightRule(rs ruleStruct, ep EqualityProblem, father_chan chan answerEP
 			tryEqualityReasoningProblem(makeEqualityProblem(ep.copy().GetE(), rs.getS(), new_term.Copy(), new_cl), father_chan, rs.getIndexEQList(), RIGHT, father_id)
 		}
 	} else {
-		Glob.PrintDebug(
-			"ARR",
+		debug(
 			Lib.MkLazy(func() string { return "Not consistant with LPO, send nil" }),
 		)
 		father_chan <- makeEmptyAnswerEP()
-		Glob.PrintDebug("ARR", Lib.MkLazy(func() string { return "Die" }))
+		debug(Lib.MkLazy(func() string { return "Die" }))
 	}
 }
 
@@ -140,20 +129,17 @@ func applyRightRule(rs ruleStruct, ep EqualityProblem, father_chan chan answerEP
 * sub_term_of s is a subterm of s unifible with l
 **/
 func applyEQRule(l, r, sub_term_of_s, s, t AST.Term, cs ConstraintStruct) (bool, AST.Term, ConstraintStruct) {
-	Glob.PrintDebug(
-		"AEQR",
+	debug(
 		Lib.MkLazy(func() string { return "Apply eq rule" }),
 	)
-	Glob.PrintDebug(
-		"AEQR",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Replace %v by %v in %v", sub_term_of_s.ToString(), r.ToString(), s.ToString())
 		}),
 	)
 	new_s := s.Copy().ReplaceSubTermBy(sub_term_of_s, r)
-	Glob.PrintDebug(
-		"AEQR",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("s = %v, new_s = %v", s.ToString(), new_s.ToString()) }),
 	)
 	constraints_list := cs.copy()

--- a/src/Mods/equality/bse/equality_rules_reasoning.go
+++ b/src/Mods/equality/bse/equality_rules_reasoning.go
@@ -66,8 +66,7 @@ func (bes *BasicEqualityStruct) AddGoal(goal []eqStruct.TermPair) {
 }
 
 func (bes *BasicEqualityStruct) Solve() (subs []Unif.Substitutions, success bool) {
-	Glob.PrintDebug(
-		"ERML",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Start of Equality reasoning multilist : %v",
@@ -80,13 +79,11 @@ func (bes *BasicEqualityStruct) Solve() (subs []Unif.Substitutions, success bool
 	for _, goal := range bes.goals.Slice() {
 		epl := makeEqualityProblemList(bes.assumptions.Slice(), goal.Slice())
 
-		Glob.PrintDebug(
-			"ERML",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("iteration on EPL : %v", epl.ToString()) }),
 		)
 		if has_solution, subst_res_tmp := equalityReasoningList(epl); has_solution {
-			Glob.PrintDebug(
-				"ERML",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Solution found for one EPL : %v !",
@@ -100,8 +97,7 @@ func (bes *BasicEqualityStruct) Solve() (subs []Unif.Substitutions, success bool
 		}
 	}
 
-	Glob.PrintDebug(
-		"ERML",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Final subst after ER : %v",
@@ -151,22 +147,19 @@ func RunEqualityReasoning(es eqStruct.EqualityStruct, epml EqualityProblemMultiL
 * Result : true if all of the problem in the list agrees on at least one substitution, and the corresponding substitutions
 **/
 func equalityReasoningList(epl EqualityProblemList) (bool, []Unif.Substitutions) {
-	Glob.PrintDebug(
-		"ERML",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Start of Equality reasoning list : %v", epl.ToString()) }),
 	)
 
 	substs_res := []Unif.Substitutions{}
 
 	for _, ep := range epl {
-		Glob.PrintDebug(
-			"ERL",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Iteration on EP : %v", ep.ToString()) }),
 		)
 		// Each step manage one problem with n subtitutions
 		if has_solution, subst_res_tmp := manageEqualityReasoningProblem(ep.copy(), substs_res); has_solution {
-			Glob.PrintDebug(
-				"ERL",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Solution found for on EP : %v !",
@@ -183,8 +176,7 @@ func equalityReasoningList(epl EqualityProblemList) (bool, []Unif.Substitutions)
 
 /* return true if at least on subst on the subst list returns result, and the corresponding substitution list */
 func manageEqualityReasoningProblem(ep EqualityProblem, sl []Unif.Substitutions) (bool, []Unif.Substitutions) {
-	Glob.PrintDebug(
-		"ERPWAS",
+	debug(
 		Lib.MkLazy(func() string { return "Start on equality reasoning  problem with apply subst" }),
 	)
 	if len(sl) == 0 {

--- a/src/Mods/equality/bse/equality_rules_try_apply.go
+++ b/src/Mods/equality/bse/equality_rules_try_apply.go
@@ -40,7 +40,6 @@ import (
 	"fmt"
 
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Mods/equality/eqStruct"
 	"github.com/GoelandProver/Goeland/Unif"
@@ -48,8 +47,7 @@ import (
 
 /* Try left rule */
 func tryApplyLeftRules(ep EqualityProblem, index_begin int) ruleStructList {
-	Glob.PrintDebug(
-		"TALR",
+	debug(
 		Lib.MkLazy(func() string { return "-- Try apply left rule" }),
 	)
 	res := ruleStructList{}
@@ -60,8 +58,7 @@ func tryApplyLeftRules(ep EqualityProblem, index_begin int) ruleStructList {
 		res = append(res, tryApplyRuleAux(eq_pair.GetT2(), eq_pair.GetT1(), ep.copy(), LEFT, false, i)...)
 		i++
 	}
-	Glob.PrintDebug(
-		"TALR",
+	debug(
 		Lib.MkLazy(func() string { return "-- End of Try apply left rule" }),
 	)
 	return res
@@ -69,15 +66,13 @@ func tryApplyLeftRules(ep EqualityProblem, index_begin int) ruleStructList {
 
 /* Try right rule */
 func tryApplyRightRules(ep EqualityProblem) ruleStructList {
-	Glob.PrintDebug(
-		"TARR",
+	debug(
 		Lib.MkLazy(func() string { return "-- Try apply right rule" }),
 	)
 	res := ruleStructList{}
 	res = append(res, tryApplyRuleAux(ep.GetS(), ep.GetT(), ep.copy(), RIGHT, true, -1)...)
 	res = append(res, tryApplyRuleAux(ep.GetT(), ep.GetS(), ep.copy(), RIGHT, false, -1)...)
-	Glob.PrintDebug(
-		"TARR",
+	debug(
 		Lib.MkLazy(func() string { return "-- End of Try apply right rule" }),
 	)
 	return res
@@ -97,12 +92,10 @@ func tryApplyRuleAux(t1, t2 AST.Term, ep EqualityProblem, ruleType int, is_s_mod
 
 // Take s, t and return a rule
 func tryApplyRuleCompute(s, t AST.Term, ep EqualityProblem, type_rule int) ruleStructList {
-	Glob.PrintDebug(
-		"TARA",
+	debug(
 		Lib.MkLazy(func() string { return "===============================================" }),
 	)
-	Glob.PrintDebug(
-		"TARA",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Try apply rule aux on : %v and %v",
@@ -114,22 +107,20 @@ func tryApplyRuleCompute(s, t AST.Term, ep EqualityProblem, type_rule int) ruleS
 
 	// Retrieve the list of substerm of s
 	subterms_of_s := s.GetSubTerms()
-	Glob.PrintDebug("TARA", Lib.MkLazy(func() string {
+	debug(Lib.MkLazy(func() string {
 		return fmt.Sprintf(
 			"len subterms found : %v - %v",
 			subterms_of_s.Len(),
 			subterms_of_s.ToString(AST.Term.ToString, ",", "[]"),
 		)
 	}))
-	Glob.PrintDebug(
-		"TARA",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("EP eq list : %v", ep.GetE().ToString()) }),
 	)
 
 	// for each l' substerm of s, return a list (l', l) unifiable
 	list_l_prime_l := searchUnifBewteenListAndEq(subterms_of_s, ep.getETree())
-	Glob.PrintDebug(
-		"TARA",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("len unifiable subterms found : %v", len(list_l_prime_l)) }),
 	)
 
@@ -142,8 +133,7 @@ func connectLAndR(list_l_prime_l []eqStruct.TermPair, ep EqualityProblem, s AST.
 	res := ruleStructList{}
 
 	for _, l_prime_l_pair := range list_l_prime_l {
-		Glob.PrintDebug(
-			"TARA",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"Subterms unifiable found : %v",
@@ -152,8 +142,7 @@ func connectLAndR(list_l_prime_l []eqStruct.TermPair, ep EqualityProblem, s AST.
 		)
 
 		for _, r := range ep.getEMap()[l_prime_l_pair.GetT2().ToString()].GetSlice() {
-			Glob.PrintDebug(
-				"TARA",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"We wish to subst %v (unifiable with %v) by %v in %v = %v",
@@ -171,14 +160,12 @@ func connectLAndR(list_l_prime_l []eqStruct.TermPair, ep EqualityProblem, s AST.
 
 			// if s = t is not l = r OR, if they are, the rule's type is right, so it's ok
 			if !s_t.EqualsModulo(l_r) || type_rule == RIGHT {
-				Glob.PrintDebug(
-					"TARA",
+				debug(
 					Lib.MkLazy(func() string { return "Try apply rule ok !" }),
 				)
 				res = append(res, makeRuleStruct(type_rule, l_prime_l_pair.GetT2(), r.Copy(), l_prime_l_pair.GetT1(), s.Copy(), t.Copy()))
 			} else {
-				Glob.PrintDebug(
-					"TARA",
+				debug(
 					Lib.MkLazy(func() string { return "Don't apply an equality on itself" }),
 				)
 			}
@@ -189,7 +176,7 @@ func connectLAndR(list_l_prime_l []eqStruct.TermPair, ep EqualityProblem, s AST.
 
 /* return all the pair (l, l') unifiable */
 func searchUnifBewteenListAndEq(tl Lib.List[AST.Term], tree Unif.DataStructure) []eqStruct.TermPair {
-	Glob.PrintDebug("SUBLE", Lib.MkLazy(func() string {
+	debug(Lib.MkLazy(func() string {
 		return fmt.Sprintf(
 			"Searching unfication between %v and the eq tree",
 			tl.ToString(AST.Term.ToString, ",", "[]"),
@@ -198,37 +185,31 @@ func searchUnifBewteenListAndEq(tl Lib.List[AST.Term], tree Unif.DataStructure) 
 	term_pair_list := []eqStruct.TermPair{}
 	for _, t_prime := range tl.GetSlice() {
 		// If the subterm is not a variable
-		Glob.PrintDebug(
-			"SUBLE",
+		debug(
 			Lib.MkLazy(func() string { return "------------------------------------------" }),
 		)
-		Glob.PrintDebug(
-			"SUBLE",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Current subterm : %v", t_prime.ToString()) }),
 		)
 		if !t_prime.IsMeta() {
 			res, tl := checkUnifInTree(t_prime, tree)
 			if res {
-				Glob.PrintDebug(
-					"SUBLE",
+				debug(
 					Lib.MkLazy(func() string { return "Unification found !" }),
 				)
 				for _, t := range tl.GetSlice() {
-					Glob.PrintDebug(
-						"SUBLE",
+					debug(
 						Lib.MkLazy(func() string { return fmt.Sprintf("Unif found with : %v", t.ToString()) }),
 					)
 					term_pair_list = append(term_pair_list, eqStruct.MakeTermPair(t_prime, t))
 				}
 			} else {
-				Glob.PrintDebug(
-					"SUBLE",
+				debug(
 					Lib.MkLazy(func() string { return "Unification not found !" }),
 				)
 			}
 		} else {
-			Glob.PrintDebug(
-				"SUBLE",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a meta !", t_prime.ToString()) }),
 			)
 		}
@@ -246,8 +227,7 @@ func checkUnifInTree(t AST.Term, tree Unif.DataStructure) (bool, Lib.List[AST.Te
 	}
 
 	for _, subst := range ms {
-		Glob.PrintDebug(
-			"CUIT",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf("Unif found with %v :%v",
 					subst.GetForm().ToString(), subst.GetSubst().ToString())

--- a/src/Mods/equality/bse/equality_rules_utils.go
+++ b/src/Mods/equality/bse/equality_rules_utils.go
@@ -76,13 +76,12 @@ func tryUnifySAndT(s, t AST.Term) (bool, Unif.Substitutions) {
 /* check unfiication */
 func checkUnif(ep EqualityProblem) (found bool, substs_res []Unif.Substitutions) {
 	if ok, subst_found := tryUnifySAndT(ep.GetS(), ep.GetT()); ok {
-		Glob.PrintDebug("ERP", Lib.MkLazy(func() string { return "Unif found !" }))
+		debug(Lib.MkLazy(func() string { return "Unif found !" }))
 		new_subst := Unif.AddUnification(ep.GetS(), ep.GetT(), ep.getC().getSubst())
 		if !new_subst.Equals(Unif.Failure()) {
 			is_consistant := ep.c.getPrec().isConsistantWithSubst(new_subst)
 			if is_consistant {
-				Glob.PrintDebug(
-					"ERP",
+				debug(
 					Lib.MkLazy(func() string {
 						return fmt.Sprintf(
 							"Unif found and consistant : %v", new_subst.ToString())
@@ -91,8 +90,7 @@ func checkUnif(ep EqualityProblem) (found bool, substs_res []Unif.Substitutions)
 				found = true
 				substs_res = append(substs_res, new_subst)
 			} else {
-				Glob.PrintDebug(
-					"ERP",
+				debug(
 					Lib.MkLazy(func() string {
 						return fmt.Sprintf(
 							"Unif found but not consistant : %v", subst_found.ToString())
@@ -100,8 +98,7 @@ func checkUnif(ep EqualityProblem) (found bool, substs_res []Unif.Substitutions)
 				)
 			}
 		} else {
-			Glob.PrintDebug(
-				"ERP",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Unif found but not consistant with other unifications : %v", subst_found.ToString())
@@ -109,7 +106,7 @@ func checkUnif(ep EqualityProblem) (found bool, substs_res []Unif.Substitutions)
 			)
 		}
 	} else {
-		Glob.PrintDebug("ERP", Lib.MkLazy(func() string { return "Unification not found" }))
+		debug(Lib.MkLazy(func() string { return "Unification not found" }))
 	}
 	return found, substs_res
 }

--- a/src/Mods/equality/bse/lpo.go
+++ b/src/Mods/equality/bse/lpo.go
@@ -66,27 +66,23 @@ func makeEmptyCompareStruct() compareStruct {
 *	two terms : the new terms for the constraint (if not comparable)
 **/
 func compareLPO(s, t AST.Term) compareStruct {
-	Glob.PrintDebug(
-		"CPR",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Compare %v and %v", s.ToString(), t.ToString()) }),
 	)
 	switch s_type := s.(type) {
 	case AST.Fun:
-		Glob.PrintDebug(
-			"CPR",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("%v is a function", s.ToString()) }),
 		)
 		switch t_type := t.(type) {
 		case AST.Fun:
-			Glob.PrintDebug(
-				"CPR",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a function", t.ToString()) }),
 			)
 			// function and function
 			return compareFunFun(s_type, t_type)
 		case AST.Meta:
-			Glob.PrintDebug(
-				"CPR",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a Meta", t.ToString()) }),
 			)
 			// function & meta : Occurences inside : f(x) < x, f(y) < x
@@ -95,21 +91,18 @@ func compareLPO(s, t AST.Term) compareStruct {
 			Glob.PrintError("CPR", "Type of t unknown")
 		}
 	case AST.Meta:
-		Glob.PrintDebug(
-			"CPR",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("%v is a Meta", s.ToString()) }),
 		)
 		switch t_type := t.(type) {
 		case AST.Fun:
-			Glob.PrintDebug(
-				"CPR",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a function", t.ToString()) }),
 			)
 			// meta & function : Occurences inside : x < f(x), x < f(y)
 			return compareMetaFun(s_type, t_type, 1)
 		case AST.Meta:
-			Glob.PrintDebug(
-				"CPR",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("%v is a Meta", t.ToString()) }),
 			)
 			// Meta and meta
@@ -130,21 +123,18 @@ func compareLPO(s, t AST.Term) compareStruct {
 * For example, x < f(x) is ok but f(x) < x isn't
 **/
 func compareMetaFun(m AST.Meta, f AST.Fun, return_code int) compareStruct {
-	Glob.PrintDebug(
-		"CMF",
+	debug(
 		Lib.MkLazy(func() string { return "Compare Meta Fun" }),
 	)
 	// Check argument inside f
 	if found, res := compareMetaFunInside(m, f, return_code); found {
-		Glob.PrintDebug(
-			"CMF",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Found after compare inside : %v", res) }),
 		)
 		return res
 	}
 
-	Glob.PrintDebug(
-		"CMF",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Not found and return_code is %v", return_code) }),
 	)
 	// f has no args or all respect LPO
@@ -156,8 +146,7 @@ func compareMetaFun(m AST.Meta, f AST.Fun, return_code int) compareStruct {
 }
 
 func compareMetaFunInside(m AST.Meta, f AST.Fun, return_code int) (bool, compareStruct) {
-	Glob.PrintDebug(
-		"CMFI",
+	debug(
 		Lib.MkLazy(func() string { return "Compare Meta Fun Inside" }),
 	)
 	i := 0
@@ -201,8 +190,7 @@ func compareMetaMeta(m1, m2 AST.Meta) compareStruct {
 
 /* Compare two functions */
 func compareFunFun(s, t AST.Fun) compareStruct {
-	Glob.PrintDebug(
-		"CFF",
+	debug(
 		Lib.MkLazy(func() string { return "Compare Fun Fun" }),
 	)
 
@@ -248,8 +236,7 @@ func caseFLessG(s, t AST.Fun) (bool, compareStruct) {
 
 /* Case f == g */
 func caseFEqualsG(s, t AST.Fun) (bool, compareStruct) {
-	Glob.PrintDebug(
-		"F=G",
+	debug(
 		Lib.MkLazy(func() string { return "Case F = G" }),
 	)
 	if s.GetArgs().Len() != t.GetArgs().Len() {
@@ -267,8 +254,7 @@ func caseFEqualsG(s, t AST.Fun) (bool, compareStruct) {
 
 		// Bug here : les autres arguments !
 		if !cs.is_comparable {
-			Glob.PrintDebug(
-				"F=G",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Not comparable, return : %v and %v",

--- a/src/Search/child_management.go
+++ b/src/Search/child_management.go
@@ -78,9 +78,8 @@ func MakeWcdArgs(
 }
 
 func (args wcdArgs) printDebugMessages() {
-	Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Waiting children" }))
-	Glob.PrintDebug(
-		"WC",
+	debug(Lib.MkLazy(func() string { return "Waiting children" }))
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Id : %v, original node id :%v",
@@ -88,12 +87,10 @@ func (args wcdArgs) printDebugMessages() {
 				args.originalNodeId)
 		}),
 	)
-	Glob.PrintDebug(
-		"WC",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Child order : %v", args.childOrdering) }),
 	)
-	Glob.PrintDebug(
-		"WC",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Children : %v, BT_subst : %v, BT_formulas : %v, bt_bool : %v, Given_subst : %v, applied subst : %v, subst_found : %v",
@@ -106,13 +103,13 @@ func (args wcdArgs) printDebugMessages() {
 				Core.SubstAndFormListToString(args.st.GetSubstsFound()))
 		}),
 	)
-	Glob.PrintDebug("WC", Lib.MkLazy(func() string {
+	debug(Lib.MkLazy(func() string {
 		return fmt.Sprintf(
 			"MM : %v",
 			Lib.ListToString(args.st.GetMM().Elements(), ",", "[]"),
 		)
 	}))
-	Glob.PrintDebug("WC", Lib.MkLazy(func() string {
+	debug(Lib.MkLazy(func() string {
 		return fmt.Sprintf(
 			"MC : %v",
 			Lib.ListToString(args.st.GetMC().Elements(), ",", "[]"),
@@ -123,7 +120,7 @@ func (args wcdArgs) printDebugMessages() {
 /* Utilitary subfunctions */
 
 func (ds *destructiveSearch) childrenClosedByThemselves(args wcdArgs, proofChildren [][]ProofStruct) error {
-	Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "All children has finished by themselves" }))
+	debug(Lib.MkLazy(func() string { return "All children has finished by themselves" }))
 
 	// All children are closed & did not send any subst, i.e., they can be closed.
 	closeChildren(&args.children, true)
@@ -159,8 +156,7 @@ func (ds *destructiveSearch) childrenClosedByThemselves(args wcdArgs, proofChild
 }
 
 func (ds *destructiveSearch) passSubstToParent(args wcdArgs, proofChildren [][]ProofStruct, substs []Core.SubstAndForm) error {
-	Glob.PrintDebug(
-		"WC",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"All children agree on the substitution(s) : %v",
@@ -171,8 +167,7 @@ func (ds *destructiveSearch) passSubstToParent(args wcdArgs, proofChildren [][]P
 	// Updates the proof with what the children have found
 	args.st = updateProof(args, proofChildren)
 	newMetas := args.toReintroduce
-	Glob.PrintDebug(
-		"WC",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"new meta to reintroduce: %v",
@@ -185,8 +180,7 @@ func (ds *destructiveSearch) passSubstToParent(args wcdArgs, proofChildren [][]P
 	resultingSubsts := []Unif.Substitutions{}
 
 	for _, subst := range substs {
-		Glob.PrintDebug(
-			"WC",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"Check the susbt, remove useless element and merge with applied subst :%v",
@@ -223,8 +217,7 @@ func (ds *destructiveSearch) passSubstToParent(args wcdArgs, proofChildren [][]P
 			}
 
 			newMetas = Glob.UnionIntList(newMetas, retrieveMetaFromSubst(cleaned))
-			Glob.PrintDebug(
-				"WC",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"New meta to reintroduce in loop: %v - %v ",
@@ -233,7 +226,7 @@ func (ds *destructiveSearch) passSubstToParent(args wcdArgs, proofChildren [][]P
 				}))
 
 		} else {
-			Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Subst empty" }))
+			debug(Lib.MkLazy(func() string { return "Subst empty" }))
 		}
 	}
 
@@ -256,8 +249,7 @@ func (ds *destructiveSearch) passSubstToParent(args wcdArgs, proofChildren [][]P
 // If there is a problem of a child always checking the same substitution, it can be avoided here.
 func (bs *destructiveSearch) passSubstToChildren(args wcdArgs, substs []Core.SubstAndForm) {
 	subst, resultingSubsts := bs.chooseSubstitutionDestructive(Core.CopySubstAndFormList(substs), args.st.GetMM())
-	Glob.PrintDebug(
-		"WC",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"There is more than one substitution, choose one : %v and send it to children",
@@ -277,8 +269,7 @@ func (bs *destructiveSearch) passSubstToChildren(args wcdArgs, substs []Core.Sub
 }
 
 func (ds *destructiveSearch) manageOpenedChild(args wcdArgs) {
-	Glob.PrintDebug(
-		"WC",
+	debug(
 		Lib.MkLazy(func() string {
 			return "Open children previously found, tell to children to wait for me and try another substitution"
 		}),
@@ -291,10 +282,10 @@ func (ds *destructiveSearch) manageOpenedChild(args wcdArgs) {
 	}
 
 	if args.st.GetBTOnFormulas() && len(args.formsBT) > 0 {
-		Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Backtrack on DMT formulas." }))
+		debug(Lib.MkLazy(func() string { return "Backtrack on DMT formulas." }))
 		ds.manageBacktrackForDMT(args)
 	} else if len(args.substsBT) > 0 {
-		Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Backtrack on substitutions." }))
+		debug(Lib.MkLazy(func() string { return "Backtrack on substitutions." }))
 		newSubst := ds.tryBTSubstitution(&args.substsBT, args.st.GetMM(), args.children)
 		WriteExchanges(args.fatherId, args.st, []Core.SubstAndForm{newSubst}, Core.MakeEmptySubstAndForm(), "WaitChildren - Backtrack on substitutions.")
 		// Mutually exclusive cases: when a backtrack is done on substitutions, this backtrack is prioritised from now on.
@@ -302,16 +293,14 @@ func (ds *destructiveSearch) manageOpenedChild(args wcdArgs) {
 		args.overwrite = false
 		ds.waitChildren(args)
 	} else {
-		Glob.PrintDebug(
-			"WC",
+		debug(
 			Lib.MkLazy(func() string { return "A child is opened but no more backtracks are available." }),
 		)
 		WriteExchanges(args.fatherId, args.st, args.givenSubsts, args.currentSubst, "WaitChildren - Die - No more BT available")
 
 		// In the complete version, we just have to restart the proofsearch forbidding the bad substitutions.
 		if Glob.GetCompleteness() && len(args.children) > 1 && !args.currentSubst.IsEmpty() {
-			Glob.PrintDebug(
-				"WC",
+			debug(
 				Lib.MkLazy(func() string { return "Restart proof with forbidden substitutions." }),
 			)
 			sendForbiddenToChildren(args.children, args.st.GetForbiddenSubsts())
@@ -319,8 +308,7 @@ func (ds *destructiveSearch) manageOpenedChild(args wcdArgs) {
 			args.currentSubst = Core.MakeEmptySubstAndForm()
 			ds.waitChildren(args)
 		} else {
-			Glob.PrintDebug(
-				"WC",
+			debug(
 				Lib.MkLazy(func() string { return "No solution. You should launch in complete mode." }),
 			)
 			closeChildren(&args.children, true)
@@ -350,7 +338,7 @@ func (ds *destructiveSearch) manageBacktrackForDMT(args wcdArgs) {
 	copiedState := args.st.Copy()
 	communicationChild := Communication{make(chan bool), make(chan Result)}
 	go ds.ProofSearch(Glob.GetGID(), copiedState, communicationChild, nextSaF.GetSaf().ToSubstAndForm(), childNode, args.originalNodeId, args.toReintroduce, false)
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "GO !" }))
+	debug(Lib.MkLazy(func() string { return "GO !" }))
 	Glob.IncrGoRoutine(1)
 
 	args.children = []Communication{communicationChild}

--- a/src/Search/children.go
+++ b/src/Search/children.go
@@ -122,8 +122,7 @@ func removeChildren(s []Communication, removals Lib.Set[Lib.Int]) []Communicatio
 * kill = true : kill the children  false : wait father
 **/
 func closeChildren(children *[]Communication, kill bool) {
-	Glob.PrintDebug(
-		"CC",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Close children : %v,  order : %v", len(*children), kill) }),
 	)
 
@@ -131,10 +130,9 @@ func closeChildren(children *[]Communication, kill bool) {
 	for i, v := range *children {
 		select {
 		case v.quit <- kill:
-			Glob.PrintDebug("CC", Lib.MkLazy(func() string { return "Send close order" }))
+			debug(Lib.MkLazy(func() string { return "Send close order" }))
 		case res := <-v.result:
-			Glob.PrintDebug(
-				"CC",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Receive answer : %v and then send close order",
@@ -144,8 +142,7 @@ func closeChildren(children *[]Communication, kill bool) {
 			if res.need_answer {
 				v.quit <- kill
 			} else {
-				Glob.PrintDebug(
-					"CC",
+				debug(
 					Lib.MkLazy(func() string { return "Not send, child already dead" }),
 				)
 				delayed_removal = delayed_removal.Add(Lib.MkInt(i))
@@ -160,13 +157,11 @@ func closeChildren(children *[]Communication, kill bool) {
 
 /* Send a substitution to a list of child */
 func sendSubToChildren(children []Communication, s Core.SubstAndForm) {
-	Glob.PrintDebug(
-		"SSTC",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Send sub to children : %v", len(children)) }),
 	)
 	for i, v := range children {
-		Glob.PrintDebug(
-			"SSTC",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("children : %v/%v", i+1, len(children)) }),
 		)
 		v.result <- Result{Glob.GetGID(), true, true, s.Copy(), []Core.SubstAndForm{}, Unif.MakeEmptySubstitutionList(), nil, -1, -1, Core.MakeUnifier()}
@@ -175,13 +170,11 @@ func sendSubToChildren(children []Communication, s Core.SubstAndForm) {
 
 /* Send a substitution to a list of child */
 func sendForbiddenToChildren(children []Communication, s []Unif.Substitutions) {
-	Glob.PrintDebug(
-		"SFTC",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Send forbidden to children : %v", len(children)) }),
 	)
 	for i, v := range children {
-		Glob.PrintDebug(
-			"SFTC",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("children : %v/%v", i+1, len(children)) }),
 		)
 		v.result <- Result{Glob.GetGID(), true, true, Core.MakeEmptySubstAndForm(), []Core.SubstAndForm{}, s, nil, -1, -1, Core.MakeUnifier()}
@@ -191,8 +184,7 @@ func sendForbiddenToChildren(children []Communication, s []Unif.Substitutions) {
 /* Send a subst to father. Return true if the process is supposed to die after */
 func (ds *destructiveSearch) sendSubToFather(c Communication, closed, need_answer bool, father_id uint64, st State, given_substs []Core.SubstAndForm, node_id int, original_node_id int, meta_to_reintroduce []int) {
 	subst_for_father := Core.RemoveEmptySubstFromSubstAndFormList(st.GetSubstsFound())
-	Glob.PrintDebug(
-		"SSTF",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Send subst to father : %v, closed : %v, need answer : %v",
@@ -200,16 +192,14 @@ func (ds *destructiveSearch) sendSubToFather(c Communication, closed, need_answe
 				closed, need_answer)
 		}),
 	)
-	Glob.PrintDebug(
-		"SSTF",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Send answer : %v",
 				Core.SubstAndFormListToString(subst_for_father))
 		}),
 	)
-	Glob.PrintDebug(
-		"SSTF",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Id : %v, original node id :%v",
@@ -217,12 +207,10 @@ func (ds *destructiveSearch) sendSubToFather(c Communication, closed, need_answe
 				original_node_id)
 		}),
 	)
-	Glob.PrintDebug(
-		"SSTF",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Send proof : %v", ProofStructListToString(st.GetProof())) }),
 	)
-	Glob.PrintDebug(
-		"SSTF",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Meta to reintroduce: %v",
@@ -235,7 +223,7 @@ func (ds *destructiveSearch) sendSubToFather(c Communication, closed, need_answe
 		if need_answer {
 			ds.waitFather(father_id, st, c, Core.FusionSubstAndFormListWithoutDouble(subst_for_father, given_substs), node_id, original_node_id, []int{}, meta_to_reintroduce)
 		} else {
-			Glob.PrintDebug("SSTF", Lib.MkLazy(func() string { return "Die" }))
+			debug(Lib.MkLazy(func() string { return "Die" }))
 		}
 	case quit := <-c.quit:
 		ds.manageQuitOrder(quit, c, father_id, st, []Communication{}, given_substs, node_id, original_node_id, []int{}, meta_to_reintroduce)

--- a/src/Search/destructive.go
+++ b/src/Search/destructive.go
@@ -125,14 +125,12 @@ func (ds *destructiveSearch) doOneStep(limit int, formula AST.Form) (bool, int) 
 	go ds.ProofSearch(Glob.GetGID(), state, c, Core.MakeEmptySubstAndForm(), nodeId, nodeId, []int{}, false)
 	Glob.IncrGoRoutine(1)
 
-	Glob.PrintDebug("MAIN", Lib.MkLazy(func() string { return "GO" }))
+	debug(Lib.MkLazy(func() string { return "GO" }))
 
-	Glob.PrintDebug(
-		"MAIN",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Nb of goroutines = %d", Glob.GetNbGoroutines()) }),
 	)
-	Glob.PrintDebug(
-		"MAIN",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("%v goroutines still running", runtime.NumGoroutine()) }),
 	)
 
@@ -156,10 +154,9 @@ func (ds *destructiveSearch) doOneStep(limit int, formula AST.Form) (bool, int) 
 
 /* Choose a substitution (backtrack) */
 func (ds *destructiveSearch) tryBTSubstitution(spc *([]Core.SubstAndForm), mm Lib.Set[AST.Meta], children []Communication) Core.SubstAndForm {
-	Glob.PrintDebug("TBTS", Lib.MkLazy(func() string { return "Try another substitution." }))
+	debug(Lib.MkLazy(func() string { return "Try another substitution." }))
 	next_subst, new_spc := ds.chooseSubstitutionDestructive(Core.CopySubstAndFormList(*spc), mm)
-	Glob.PrintDebug(
-		"TBTS",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Choose the substitution : %v and send it to children",
@@ -211,8 +208,7 @@ func (ds *destructiveSearch) searchContradictionAfterApplySusbt(father_id uint64
 		return false
 	}
 	for _, f := range st.GetAtomic() {
-		Glob.PrintDebug(
-			"PS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("##### Formula %v #####", f.ToString()) }),
 		)
 		// Check if exists a contradiction after applying the substitution
@@ -229,8 +225,7 @@ func (ds *destructiveSearch) searchContradiction(atomic AST.Form, father_id uint
 	if Glob.GetAssisted() {
 		return false
 	}
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("##### Formula %v #####", atomic.ToString()) }),
 	)
 	clos_res, subst := ApplyClosureRules(atomic, &st)
@@ -253,12 +248,10 @@ func (ds *destructiveSearch) searchContradiction(atomic AST.Form, father_id uint
 * subst_found : Unif.Substitutions found by this process
 **/
 func (ds *destructiveSearch) ProofSearch(father_id uint64, st State, cha Communication, s Core.SubstAndForm, node_id int, original_node_id int, meta_to_reintroduce []int, post_dmt_step bool) {
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return "---------- New search step ----------" }),
 	)
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Child of %v - node id : %v - original node id : %v",
@@ -267,8 +260,7 @@ func (ds *destructiveSearch) ProofSearch(father_id uint64, st State, cha Communi
 				original_node_id)
 		}),
 	)
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Meta to reintroduce: %v",
@@ -287,13 +279,11 @@ func (ds *destructiveSearch) ProofSearch(father_id uint64, st State, cha Communi
 	default:
 		// Apply subst if needed
 		if !s.IsEmpty() {
-			Glob.PrintDebug(
-				"PS",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("Apply Substitution : %v", s.ToString()) }),
 			)
 			ApplySubstitution(&st, s)
-			Glob.PrintDebug(
-				"PS",
+			debug(
 				Lib.MkLazy(func() string { return "Searching contradiction with new atomics" }),
 			)
 			if ds.searchContradictionAfterApplySusbt(father_id, st, cha, node_id, original_node_id) {
@@ -304,8 +294,7 @@ func (ds *destructiveSearch) ProofSearch(father_id uint64, st State, cha Communi
 		// Print current state
 		st.Print()
 		if len(st.GetSubstsFound()) > 0 {
-			Glob.PrintDebug(
-				"PS",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Current substitutions list: %v",
@@ -313,13 +302,12 @@ func (ds *destructiveSearch) ProofSearch(father_id uint64, st State, cha Communi
 				}),
 			)
 		}
-		Glob.PrintDebug(
-			"PS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Formulas to be added: %v", st.GetLF().ToString()) }),
 		)
 
 		// Dispatch newly generated formulas into the right category
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Dispatch" }))
+		debug(Lib.MkLazy(func() string { return "Dispatch" }))
 		step_atomics := Core.MakeEmptyFormAndTermsList()
 		for _, f := range st.GetLF() {
 			if Core.ShowKindOfRule(f.GetForm()) == Core.Atomic {
@@ -334,17 +322,14 @@ func (ds *destructiveSearch) ProofSearch(father_id uint64, st State, cha Communi
 		}
 
 		// DMT --- Retrieve atomics for DMT
-		Glob.PrintDebug(
-			"PS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("New atomics : %v", step_atomics.ToString()) }),
 		)
 		atomics_dmt, atomics_non_dmt := ds.getAtomicsForDMT(step_atomics, &st, s, post_dmt_step)
-		Glob.PrintDebug(
-			"PS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Atomics dmt : %v", atomics_dmt.ToString()) }),
 		)
-		Glob.PrintDebug(
-			"PS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Atomics non-dmt : %v", atomics_non_dmt.ToString()) }),
 		)
 
@@ -358,12 +343,10 @@ func (ds *destructiveSearch) ProofSearch(father_id uint64, st State, cha Communi
 		// Retrieve new formulas to insert into the trees
 		atomicsPlus := atomics_non_dmt.FilterLitPolarity(Core.Pos)
 		atomicsMinus := atomics_non_dmt.FilterLitPolarity(Core.Neg)
-		Glob.PrintDebug(
-			"PS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Atomic plus : %v", atomicsPlus.ToString()) }),
 		)
-		Glob.PrintDebug(
-			"PS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Atomic minus : %v", atomicsMinus.ToString()) }),
 		)
 		st.SetTreePos(st.GetTreePos().MakeDataStruct(st.GetAtomic().Merge(atomicsPlus).ExtractForms(), true))
@@ -383,12 +366,12 @@ func (ds *destructiveSearch) ProofSearch(father_id uint64, st State, cha Communi
 			}
 		}
 
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Tree Pos after insert:" }))
+		debug(Lib.MkLazy(func() string { return "Tree Pos after insert:" }))
 		st.GetTreePos().Print()
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Tree Neg after insert:" }))
+		debug(Lib.MkLazy(func() string { return "Tree Neg after insert:" }))
 		st.GetTreeNeg().Print()
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Let's apply rules !" }))
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string {
+		debug(Lib.MkLazy(func() string { return "Let's apply rules !" }))
+		debug(Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"LF before applyRules : %v",
 				st.GetLF().ToString())
@@ -439,8 +422,7 @@ func (ds *destructiveSearch) waitChildren(args wcdArgs) {
 		ds.manageQuitOrder(quit, args.c, args.fatherId, args.st, args.children, args.givenSubsts, args.nodeId, args.originalNodeId, args.childOrdering, args.toReintroduce)
 		return
 	default:
-		Glob.PrintDebug(
-			"WC",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"Current substs : %v",
@@ -448,8 +430,7 @@ func (ds *destructiveSearch) waitChildren(args wcdArgs) {
 			}),
 		)
 		status, substs, proofs, unifiers := ds.selectChildren(args.c, &args.children, args.currentSubst, args.childOrdering)
-		Glob.PrintDebug(
-			"WC",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"End of select - resulting substs : %v ",
@@ -471,11 +452,11 @@ func (ds *destructiveSearch) waitChildren(args wcdArgs) {
 			ds.passSubstToChildren(args, substs)
 		case QUIT:
 			WriteExchanges(args.fatherId, args.st, args.givenSubsts, args.currentSubst, "WaitChildren - Die")
-			Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Closing order received" }))
+			debug(Lib.MkLazy(func() string { return "Closing order received" }))
 			ds.manageQuitOrder(true, args.c, args.fatherId, args.st, args.children, []Core.SubstAndForm{}, args.nodeId, args.originalNodeId, args.childOrdering, args.toReintroduce)
 		case WAIT:
 			WriteExchanges(args.fatherId, args.st, args.givenSubsts, args.currentSubst, "WaitChildren - Wait father")
-			Glob.PrintDebug("WC", Lib.MkLazy(func() string { return "Closing order received, let's wait father" }))
+			debug(Lib.MkLazy(func() string { return "Closing order received, let's wait father" }))
 			closeChildren(&args.children, true)
 			ds.waitFather(args.fatherId, args.st, args.c, args.givenSubsts, args.nodeId, args.originalNodeId, args.childOrdering, args.toReintroduce)
 		case OPENED:
@@ -499,7 +480,7 @@ func (ds *destructiveSearch) waitChildren(args wcdArgs) {
 * 	given_substs : subst send by this node to its father
 **/
 func (ds *destructiveSearch) waitFather(father_id uint64, st State, c Communication, given_substs []Core.SubstAndForm, node_id int, original_node_id int, child_order []int, meta_to_reintroduce []int) {
-	Glob.PrintDebug("WF", Lib.MkLazy(func() string { return "Wait father" }))
+	debug(Lib.MkLazy(func() string { return "Wait father" }))
 
 	// CLear subst found
 	st.SetSubstsFound([]Core.SubstAndForm{})
@@ -515,15 +496,13 @@ func (ds *destructiveSearch) waitFather(father_id uint64, st State, c Communicat
 
 		// Update to prune everything that shouldn't happen.
 		WriteExchanges(father_id, st, given_substs, subst, "WaitFather")
-		Glob.PrintDebug(
-			"WF",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Substition received : %v", subst.ToString()) }),
 		)
 
 		// Check if the subst was already seen, returns eventually the subst with new formula(s)
 		if Unif.ContainsSubst(Core.GetSubstListFromSubstAndFormList(given_substs), answer_father.subst_for_children.GetSubst()) {
-			Glob.PrintDebug(
-				"WF",
+			debug(
 				Lib.MkLazy(func() string { return "This substitution was sent by this child" }),
 			)
 			for _, subst_sent := range given_substs {
@@ -552,8 +531,7 @@ func (ds *destructiveSearch) waitFather(father_id uint64, st State, c Communicat
 
 			// Maj forbidden
 			if len(answer_father.forbidden) > 0 {
-				Glob.PrintDebug(
-					"WF",
+				debug(
 					Lib.MkLazy(func() string {
 						return fmt.Sprintf(
 							"Forbidden received : %v",
@@ -561,8 +539,7 @@ func (ds *destructiveSearch) waitFather(father_id uint64, st State, c Communicat
 					}),
 				)
 				st.SetForbiddenSubsts(answer_father.getForbiddenSubsts())
-				Glob.PrintDebug(
-					"WF",
+				debug(
 					Lib.MkLazy(func() string {
 						return fmt.Sprintf(
 							"New forbidden fo this state : %v",
@@ -581,7 +558,7 @@ func (ds *destructiveSearch) waitFather(father_id uint64, st State, c Communicat
 				}
 				// Set to MM
 				st.SetMM(meta_sisters)
-				Glob.PrintDebug("WF", Lib.MkLazy(func() string {
+				debug(Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"MC after sisters : %v",
 						Lib.ListToString(meta_sisters.Elements(), ",", "[]"),
@@ -617,16 +594,14 @@ func (ds *destructiveSearch) waitFather(father_id uint64, st State, c Communicat
 
 			c2 := Communication{make(chan bool), make(chan Result)}
 
-			Glob.PrintDebug(
-				"WF",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Apply substitution on myself and wait : %v",
 						answer_father.getSubstForChildren().GetSubst().ToString())
 				}),
 			)
-			Glob.PrintDebug(
-				"WF",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf("Forbidden : %v", Unif.SubstListToString(st_copy.GetForbiddenSubsts()))
 				}),
@@ -634,7 +609,7 @@ func (ds *destructiveSearch) waitFather(father_id uint64, st State, c Communicat
 			go ds.ProofSearch(Glob.GetGID(), st_copy, c2, answer_father.getSubstForChildren(), node_id, original_node_id, new_meta_to_reintroduce, false)
 			Glob.IncrGoRoutine(1)
 
-			Glob.PrintDebug("WF", Lib.MkLazy(func() string { return "GO !" }))
+			debug(Lib.MkLazy(func() string { return "GO !" }))
 			st.SetBTOnFormulas(false)
 			ds.waitChildren(MakeWcdArgs(father_id, st, c, []Communication{c2}, given_substs, answer_father.getSubstForChildren(), []Core.SubstAndForm{}, []Core.IntSubstAndFormAndTerms{}, node_id, original_node_id, true, []int{original_node_id}, meta_to_reintroduce))
 		}
@@ -647,10 +622,10 @@ func (ds *destructiveSearch) manageQuitOrder(quit bool, c Communication, father_
 		closeChildren(&children, true)
 	}
 	if quit {
-		Glob.PrintDebug("MQO", Lib.MkLazy(func() string { return "Closing order received" }))
-		Glob.PrintDebug("MQO", Lib.MkLazy(func() string { return "Die" }))
+		debug(Lib.MkLazy(func() string { return "Closing order received" }))
+		debug(Lib.MkLazy(func() string { return "Die" }))
 	} else {
-		Glob.PrintDebug("MQO", Lib.MkLazy(func() string { return "Closing order received, let's wait father" }))
+		debug(Lib.MkLazy(func() string { return "Closing order received, let's wait father" }))
 		ds.waitFather(father_id, st, c, given_substs, node_id, original_node_id, child_order, meta_to_reintroduce)
 	}
 }
@@ -706,8 +681,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 
 	// Until all the children have answered
 	for cpt_remaining_children > 0 && result_int < QUIT {
-		Glob.PrintDebug(
-			"SLC",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"Size of remaining children : %v",
@@ -716,13 +690,13 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 		)
 
 		index, value, _ := reflect.Select(cases)
-		Glob.PrintDebug("SLC", Lib.MkLazy(func() string { return "Answer received" }))
+		debug(Lib.MkLazy(func() string { return "Answer received" }))
 
 		// Manage quit order
 		if index == index_quit {
-			Glob.PrintDebug("SLC", Lib.MkLazy(func() string { return "Quit order" }))
+			debug(Lib.MkLazy(func() string { return "Quit order" }))
 			if !value.Interface().(bool) {
-				Glob.PrintDebug("SLC", Lib.MkLazy(func() string { return "Quit order says to wait father" }))
+				debug(Lib.MkLazy(func() string { return "Quit order says to wait father" }))
 				result_int = WAIT
 			} else {
 				result_int = QUIT
@@ -742,12 +716,11 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 			proof_tab[index_children] = res.getProof()
 
 			// Remove children from waiting children
-			Glob.PrintDebug(
-				"SLC",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("Child %v has finished", res.id) }),
 			)
 			if !res.need_answer {
-				Glob.PrintDebug("SLC", Lib.MkLazy(func() string { return fmt.Sprintf("Child %v die", res.id) }))
+				debug(Lib.MkLazy(func() string { return fmt.Sprintf("Child %v die", res.id) }))
 				delayed_removals = delayed_removals.Add(Lib.MkInt(index))
 			}
 
@@ -757,8 +730,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 				unifiers = append(unifiers, unif)
 
 				if len(res.subst_list_for_father) != 0 {
-					Glob.PrintDebug(
-						"SLC",
+					debug(
 						Lib.MkLazy(func() string {
 							return fmt.Sprintf(
 								"The child %v has %v substitution(s) !",
@@ -768,8 +740,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 					)
 
 					if len(res.subst_list_for_father) == 1 && res.subst_list_for_father[0].GetSubst().Equals(current_subst.GetSubst()) {
-						Glob.PrintDebug(
-							"SLC",
+						debug(
 							Lib.MkLazy(func() string {
 								return fmt.Sprintf(
 									"The child %v returns the current subst !",
@@ -787,8 +758,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 						for _, current_subst_from_children := range res.subst_list_for_father {
 							for i := range result_subst {
 								if current_subst_from_children.GetSubst().Equals(result_subst[i].GetSubst()) {
-									Glob.PrintDebug(
-										"SLC",
+									debug(
 										Lib.MkLazy(func() string {
 											return fmt.Sprintf(
 												"Subst in common found : %v !",
@@ -802,8 +772,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 
 						// Add new subst to result subst
 						for _, v := range res.subst_list_for_father {
-							Glob.PrintDebug(
-								"SLC",
+							debug(
 								Lib.MkLazy(func() string {
 									return fmt.Sprintf(
 										"Check if the substitution was already found by another child : %v\n",
@@ -812,8 +781,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 							)
 							if !v.GetSubst().Equals(new_current_subst.GetSubst()) {
 								added := false
-								Glob.PrintDebug(
-									"SLC",
+								debug(
 									Lib.MkLazy(func() string {
 										return fmt.Sprintf(
 											"Result_subst :%v",
@@ -823,8 +791,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 								for i := range result_subst {
 									if v.GetSubst().Equals(result_subst[i].GetSubst()) {
 										added = true
-										Glob.PrintDebug(
-											"SLC",
+										debug(
 											Lib.MkLazy(func() string { return "Subst already in result_subst" }),
 										)
 										result_subst[i] = result_subst[i].AddFormulas(v.GetForm())
@@ -832,8 +799,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 								}
 
 								if !added {
-									Glob.PrintDebug(
-										"SLC",
+									debug(
 										Lib.MkLazy(func() string {
 											return fmt.Sprintf(
 												"New susbt found : %v",
@@ -841,8 +807,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 										}),
 									)
 									result_subst = Core.AppendIfNotContainsSubstAndForm(result_subst, v)
-									Glob.PrintDebug(
-										"SLC",
+									debug(
 										Lib.MkLazy(func() string {
 											return fmt.Sprintf(
 												"New result susbt : %v",
@@ -859,8 +824,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 
 			} else {
 				// Signal to children to stop and wait father for a new order
-				Glob.PrintDebug(
-					"SLC",
+				debug(
 					Lib.MkLazy(func() string {
 						return fmt.Sprintf(
 							"Open child found : %v ! - tell to remaining children to wait father",
@@ -874,8 +838,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 
 	*children = removeChildren(*children, delayed_removals)
 
-	Glob.PrintDebug(
-		"SLC",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"All answer received - subst_for_children : %v",
@@ -888,8 +851,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 		case 0:
 			if current_subst_seen {
 				// A child returns current subst and the other nothing
-				Glob.PrintDebug(
-					"SLC",
+				debug(
 					Lib.MkLazy(func() string { return "One on more children returns the current subst" }),
 				)
 				result_int = SUBST_FOR_PARENT
@@ -899,7 +861,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 			}
 		case 1:
 			// A child returns subst(s)
-			Glob.PrintDebug("SLC", Lib.MkLazy(func() string { return "A child returns new subst(s)" }))
+			debug(Lib.MkLazy(func() string { return "A child returns new subst(s)" }))
 			result_int = SUBST_FOR_PARENT
 
 			// Merge the subst with current subst (if not empty)
@@ -918,8 +880,7 @@ func (ds *destructiveSearch) selectChildren(father Communication, children *[]Co
 				}
 				result_subst = Core.CopySubstAndFormList(new_result_subst)
 			}
-			Glob.PrintDebug(
-				"SLC",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"New subst at the end : %v",
@@ -951,9 +912,8 @@ func (ds *destructiveSearch) DoEndManageBeta(fatherId uint64, state State, c Com
 }
 
 func (ds *destructiveSearch) manageRewriteRules(fatherId uint64, state State, c Communication, newAtomics Core.FormAndTermsList, currentNodeId int, originalNodeId int, metaToReintroduce []int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Try rewrite rule" }))
-	Glob.PrintDebug(
-		"PS - MRR",
+	debug(Lib.MkLazy(func() string { return "Try rewrite rule" }))
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Id : %v, original node id :%v",
@@ -964,14 +924,13 @@ func (ds *destructiveSearch) manageRewriteRules(fatherId uint64, state State, c 
 
 	// For each atomic
 	for len(remainingAtomics) > 0 {
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Remaining atomic > 0" }))
+		debug(Lib.MkLazy(func() string { return "Remaining atomic > 0" }))
 
 		// Take the first element in the list of atomics
 		f := remainingAtomics[0].Copy()
 		remainingAtomics = remainingAtomics[1:].Copy()
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("Choose : %v", f.ToString()) }))
-		Glob.PrintDebug(
-			"PS",
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("Choose : %v", f.ToString()) }))
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Remaining atomics %v", remainingAtomics.ToString()) }),
 		)
 
@@ -992,10 +951,9 @@ func (ds *destructiveSearch) manageRewriteRules(fatherId uint64, state State, c 
 	ds.ProofSearch(fatherId, state, c, Core.MakeEmptySubstAndForm(), currentNodeId, originalNodeId, []int{}, true)
 }
 
-// ILL TODO: check if this function does not make the DMT version lose completeness: is the original formula that's rewritten still in the branch or not?
+// FIXME: check if this function does not make the DMT version lose completeness: is the original formula that's rewritten still in the branch or not?
 func (ds *destructiveSearch) tryRewrite(rewritten []Core.IntSubstAndForm, f Core.FormAndTerms, state *State, remainingAtomics Core.FormAndTermsList, fatherId uint64, c Communication, currentNodeId int, originalNodeId int, metaToReintroduce []int) bool {
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Try to rewrite into :  %v",
@@ -1042,14 +1000,13 @@ func (ds *destructiveSearch) tryRewrite(rewritten []Core.IntSubstAndForm, f Core
 
 		channelChild := Communication{make(chan bool), make(chan Result)}
 		go ds.ProofSearch(Glob.GetGID(), otherState, channelChild, choosenRewritten.GetSaf().ToSubstAndForm(), childNode, childNode, []int{}, false)
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "GO !" }))
+		debug(Lib.MkLazy(func() string { return "GO !" }))
 		Glob.IncrGoRoutine(1)
 		ds.waitChildren(MakeWcdArgs(fatherId, *state, c, []Communication{channelChild}, []Core.SubstAndForm{}, choosenRewritten.GetSaf().ToSubstAndForm(), []Core.SubstAndForm{}, newRewritten, currentNodeId, originalNodeId, false, []int{childNode}, metaToReintroduce))
 		return true
 	} else {
 		// No rewriting possible
-		Glob.PrintDebug(
-			"PS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("No rewriting possible, dispatch %v", f.ToString()) }),
 		)
 		// Then add f in LF
@@ -1077,8 +1034,7 @@ func (ds *destructiveSearch) ManageClosureRule(father_id uint64, st *State, c Co
 
 	switch {
 	case len(substs) == 0:
-		Glob.PrintDebug(
-			"MCR",
+		debug(
 			Lib.MkLazy(func() string { return "Branch closed by ¬⊤ or ⊥ or a litteral and its opposite!" }),
 		)
 
@@ -1105,8 +1061,7 @@ func (ds *destructiveSearch) ManageClosureRule(father_id uint64, st *State, c Co
 		}
 
 	case len(substs_without_mm) > 0:
-		Glob.PrintDebug(
-			"MCR",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"Contradiction found (without mm) : %v",
@@ -1140,8 +1095,7 @@ func (ds *destructiveSearch) ManageClosureRule(father_id uint64, st *State, c Co
 		}
 
 	case len(substs_with_mm) > 0:
-		Glob.PrintDebug(
-			"MCR",
+		debug(
 			Lib.MkLazy(func() string { return "Contradiction found (with mm) !" }),
 		)
 
@@ -1159,16 +1113,14 @@ func (ds *destructiveSearch) ManageClosureRule(father_id uint64, st *State, c Co
 			if subst_for_father.Equals(Unif.Failure()) {
 				Glob.PrintError("MCR", fmt.Sprintf("Error : SubstForFather is failure between : %v and %v \n", subst_for_father.ToString(), st.GetAppliedSubst().ToString()))
 			}
-			Glob.PrintDebug(
-				"MCR",
+			debug(
 				Lib.MkLazy(func() string { return fmt.Sprintf("Formula = : %v", f.ToString()) }),
 			)
 
 			// Create substAndForm with the current form and the subst found
 			subst_and_form_for_father := Core.MakeSubstAndForm(subst_for_father, AST.NewFormList(f.GetForm()))
 
-			Glob.PrintDebug(
-				"MCR",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"SubstAndForm created : %v",
@@ -1192,16 +1144,14 @@ func (ds *destructiveSearch) ManageClosureRule(father_id uint64, st *State, c Co
 		if Glob.GetAssisted() {
 			return true, st.GetSubstsFound()
 		} else {
-			Glob.PrintDebug(
-				"MCR",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Subst found now : %v",
 						Core.SubstAndFormListToString(st.GetSubstsFound()))
 				}),
 			)
-			Glob.PrintDebug(
-				"MCR",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Send subst(s) with mm to father : %v",
@@ -1226,9 +1176,8 @@ func (ds *destructiveSearch) ManageClosureRule(father_id uint64, st *State, c Co
 
 /* Apply rules with priority (closure < rewrite < alpha < delta < closure with mm < beta < gamma) */
 func (ds *destructiveSearch) applyRules(fatherId uint64, state State, c Communication, atomicDMT Core.FormAndTermsList, currentNodeId int, originalNodeId int, metaToReintroduce []int) {
-	Glob.PrintDebug("AR", Lib.MkLazy(func() string { return "ApplyRule" }))
-	Glob.PrintDebug(
-		"AR",
+	debug(Lib.MkLazy(func() string { return "ApplyRule" }))
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Id : %v, original node id :%v, Child of: %v",
@@ -1238,9 +1187,9 @@ func (ds *destructiveSearch) applyRules(fatherId uint64, state State, c Communic
 		}),
 	)
 	state.Print()
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Tree Pos:" }))
+	debug(Lib.MkLazy(func() string { return "Tree Pos:" }))
 	state.GetTreePos().Print()
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Tree Neg:" }))
+	debug(Lib.MkLazy(func() string { return "Tree Neg:" }))
 	state.GetTreeNeg().Print()
 	switch {
 	case len(atomicDMT) > 0 && Glob.IsLoaded("dmt") && len(state.GetSubstsFound()) == 0:
@@ -1265,15 +1214,15 @@ func (ds *destructiveSearch) applyRules(fatherId uint64, state State, c Communic
 		WriteExchanges(fatherId, state, nil, Core.MakeEmptySubstAndForm(), "ApplyRules - SAT")
 		state.SetCurrentProofRule("Sat")
 		state.SetProof(append(state.GetProof(), state.GetCurrentProof()))
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Nothing found, return sat" }))
+		debug(Lib.MkLazy(func() string { return "Nothing found, return sat" }))
 		ds.sendSubToFather(c, false, false, fatherId, state, []Core.SubstAndForm{}, currentNodeId, originalNodeId, []int{})
 	}
 }
 
 func (ds *destructiveSearch) manageAlphaRules(fatherId uint64, state State, c Communication, originalNodeId int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Alpha rule" }))
+	debug(Lib.MkLazy(func() string { return "Alpha rule" }))
 	hdf := state.GetAlpha()[0]
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
 	state.SetAlpha(state.GetAlpha()[1:])
 	resultForms := ApplyAlphaRules(hdf, &state)
 	state.SetLF(resultForms)
@@ -1288,9 +1237,9 @@ func (ds *destructiveSearch) manageAlphaRules(fatherId uint64, state State, c Co
 }
 
 func (ds *destructiveSearch) manageDeltaRules(fatherId uint64, state State, c Communication, originalNodeId int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Delta rule" }))
+	debug(Lib.MkLazy(func() string { return "Delta rule" }))
 	hdf := state.GetDelta()[0]
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
 	state.SetDelta(state.GetDelta()[1:])
 	resultForms := ApplyDeltaRules(hdf, &state)
 	state.SetLF(resultForms)
@@ -1305,9 +1254,9 @@ func (ds *destructiveSearch) manageDeltaRules(fatherId uint64, state State, c Co
 }
 
 func (ds *destructiveSearch) manageBetaRules(fatherId uint64, state State, c Communication, currentNodeId int, originalNodeId int, metaToReintroduce []int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Beta rule" }))
+	debug(Lib.MkLazy(func() string { return "Beta rule" }))
 	hdf := state.GetBeta()[0]
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
 	reslf := ApplyBetaRules(hdf, &state)
 	childIds := []int{}
 
@@ -1337,7 +1286,7 @@ func (ds *destructiveSearch) manageBetaRules(fatherId uint64, state State, c Com
 		}
 
 		Glob.IncrGoRoutine(1)
-		Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("GO %v !", fl.GetI()) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("GO %v !", fl.GetI()) }))
 
 	}
 
@@ -1345,9 +1294,9 @@ func (ds *destructiveSearch) manageBetaRules(fatherId uint64, state State, c Com
 }
 
 func (ds *destructiveSearch) manageGammaRules(fatherId uint64, state State, c Communication, originalNodeId int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Gamma rule" }))
+	debug(Lib.MkLazy(func() string { return "Gamma rule" }))
 	hdf := state.GetGamma()[0]
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf("Rule applied on : %s", hdf.ToString()) }))
 	state.SetGamma(state.GetGamma()[1:])
 
 	// Update MetaGen
@@ -1378,9 +1327,8 @@ func (ds *destructiveSearch) manageReintroductionRules(fatherId uint64, state St
 
 	currentMTR := -1
 
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Reintroduction" }))
-	Glob.PrintDebug(
-		"PS",
+	debug(Lib.MkLazy(func() string { return "Reintroduction" }))
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Meta to reintroduce : %s",
@@ -1389,8 +1337,7 @@ func (ds *destructiveSearch) manageReintroductionRules(fatherId uint64, state St
 	)
 	newMetaGen := state.GetMetaGen()
 	reslf := Core.ReintroduceMeta(&newMetaGen, currentMTR, state.GetN())
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Reintroduce the formula : %s", reslf.ToString()) }),
 	)
 	state.SetLF(Core.MakeSingleElementFormAndTermList(reslf))
@@ -1412,16 +1359,15 @@ func (ds *destructiveSearch) manageReintroductionRules(fatherId uint64, state St
 func (ds *destructiveSearch) manageResult(c Communication) (Core.Unifier, []ProofStruct, bool) {
 	result := <-c.getResult()
 
-	Glob.PrintDebug(
-		"MAIN",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Proof : %v", ProofStructListToString(result.getProof())) }),
 	)
 
 	if result.needsAnswer() {
 		c.getQuit() <- true
-		Glob.PrintDebug("MAIN", Lib.MkLazy(func() string { return "Close order sent" }))
+		debug(Lib.MkLazy(func() string { return "Close order sent" }))
 	} else {
-		Glob.PrintDebug("MAIN", Lib.MkLazy(func() string { return "Close order not sent" }))
+		debug(Lib.MkLazy(func() string { return "Close order not sent" }))
 	}
 
 	return result.getUnifier(), result.getProof(), result.isClosed()

--- a/src/Search/exchanges.go
+++ b/src/Search/exchanges.go
@@ -128,7 +128,7 @@ func makeJsonExchanges(father_uint uint64, st State, ss_subst []Unif.Substitutio
 func WriteExchanges(father uint64, st State, sub_sent []Core.SubstAndForm, subst_received Core.SubstAndForm, calling_function string) {
 	if Glob.GetExchanges() {
 		mutex_file_exchanges.Lock()
-		Glob.PrintDebug("WG", Lib.MkLazy(func() string { return calling_function }))
+		debug(Lib.MkLazy(func() string { return calling_function }))
 		os_stat, _ := os.Stat(graph_file_name_exchanges)
 		if os_stat.Size() != 0 {
 			file_exchanges.WriteString(",\n")

--- a/src/Search/incremental/rules.go
+++ b/src/Search/incremental/rules.go
@@ -199,7 +199,7 @@ type AlphaAnd struct {
 
 func (aa *AlphaAnd) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(aa.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(aa.FullString) }))
 
 	switch form := aa.GetForm().(type) {
 	case AST.And:
@@ -217,7 +217,7 @@ type AlphaNotNot struct {
 
 func (ann *AlphaNotNot) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(ann.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(ann.FullString) }))
 
 	switch form := ann.GetForm().(type) {
 	case AST.Not:
@@ -236,7 +236,7 @@ type AlphaNotOr struct {
 
 func (ano *AlphaNotOr) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(ano.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(ano.FullString) }))
 
 	switch form := ano.GetForm().(type) {
 	case AST.Not:
@@ -257,7 +257,7 @@ type AlphaNotImp struct {
 
 func (ani *AlphaNotImp) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(ani.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(ani.FullString) }))
 
 	switch form := ani.GetForm().(type) {
 	case AST.Not:
@@ -277,7 +277,7 @@ type BetaNotAnd struct {
 
 func (bna *BetaNotAnd) apply() []RuleList {
 	resultRulesBeta := []RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bna.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bna.FullString) }))
 
 	switch form := bna.GetForm().(type) {
 	case AST.Not:
@@ -299,7 +299,7 @@ type BetaNotEqu struct {
 func (bne *BetaNotEqu) apply() []RuleList {
 	resultRules1 := RuleList{}
 	resultRules2 := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bne.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bne.FullString) }))
 
 	switch form := bne.GetForm().(type) {
 	case AST.Not:
@@ -322,7 +322,7 @@ type BetaOr struct {
 
 func (bo *BetaOr) apply() []RuleList {
 	resultRulesBeta := []RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bo.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bo.FullString) }))
 
 	switch form := bo.GetForm().(type) {
 	case AST.Or:
@@ -341,7 +341,7 @@ type BetaImp struct {
 func (bi *BetaImp) apply() []RuleList {
 	resultRules1 := RuleList{}
 	resultRules2 := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bi.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(bi.FullString) }))
 
 	switch subForm := bi.GetForm().(type) {
 	case AST.Imp:
@@ -359,7 +359,7 @@ type BetaEqu struct {
 func (be *BetaEqu) apply() []RuleList {
 	resultRules1 := RuleList{}
 	resultRules2 := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(be.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(be.FullString) }))
 
 	switch form := be.GetForm().(type) {
 	case AST.Equ:
@@ -387,7 +387,7 @@ type GammaNotExists struct {
 
 func (gne *GammaNotExists) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(gne.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(gne.FullString) }))
 
 	instanciatedForm, metas := Core.Instantiate(Core.MakeFormAndTerm(gne.GetForm(), gne.GetTerms()), 42)
 	newTerms := gne.GetTerms().Copy(AST.Term.Copy)
@@ -428,7 +428,7 @@ type GammaForall struct {
 
 func (gf *GammaForall) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(gf.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(gf.FullString) }))
 
 	instanciatedForm, metas := Core.Instantiate(Core.MakeFormAndTerm(gf.GetForm(), gf.GetTerms()), 42)
 	newTerms := gf.GetTerms().Copy(AST.Term.Copy)
@@ -466,7 +466,7 @@ type DeltaNotForall struct {
 
 func (dnf *DeltaNotForall) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(dnf.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(dnf.FullString) }))
 
 	skolemizedForm := Core.Skolemize(dnf.GetForm(), dnf.GetForm().GetMetas())
 	skolemizedFnt := Core.MakeFormAndTerm(skolemizedForm, dnf.GetTerms())
@@ -485,7 +485,7 @@ type DeltaExists struct {
 
 func (de *DeltaExists) apply() []RuleList {
 	resultRules := RuleList{}
-	Glob.PrintDebug("SRCH", Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(de.FullString) }))
+	debug(Lib.MkLazy(func() string { return "Applying " + fmt.Sprint(de.FullString) }))
 
 	skolemizedForm := Core.Skolemize(de.GetForm(), de.GetForm().GetMetas())
 	skolemizedFnt := Core.MakeFormAndTerm(skolemizedForm, de.GetTerms())

--- a/src/Search/incremental/search.go
+++ b/src/Search/incremental/search.go
@@ -11,6 +11,12 @@ import (
 
 type incrementalSearch struct{}
 
+var debug Glob.Debugger
+
+func InitDebugger() {
+	debug = Glob.CreateDebugger("incremental")
+}
+
 func NewIncrementalSearch() Search.SearchAlgorithm {
 	return &incrementalSearch{}
 }

--- a/src/Search/nonDestructiveSearch.go
+++ b/src/Search/nonDestructiveSearch.go
@@ -59,7 +59,7 @@ func (nds *nonDestructiveSearch) setApplyRules(function func(uint64, State, Comm
 }
 
 func (nds *nonDestructiveSearch) doEndManageBeta(fatherId uint64, state State, c Communication, channels []Communication, currentNodeId int, originalNodeId int, childIds []int, metaToReintroduce []int) {
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string { return "Die" }))
+	debug(Lib.MkLazy(func() string { return "Die" }))
 }
 
 func (nds *nonDestructiveSearch) manageRewriteRules(fatherId uint64, state State, c Communication, newAtomics Core.FormAndTermsList, currentNodeId int, originalNodeId int, metaToReintroduce []int) {
@@ -141,15 +141,13 @@ func (nds *nonDestructiveSearch) catchFormulaToInstantiate(subst_found Unif.Subs
 * Got the substitution (X, a) and reintroduce ForAll x P(x) -> need to reintroduce P(a). Remplace immediatly the new generated metavariable by a.
 **/
 func (nds *nonDestructiveSearch) instantiate(fatherId uint64, state *State, c Communication, index int, s Core.SubstAndForm) {
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Instantiate with subst : %v ", s.GetSubst().ToString()) }),
 	)
 	newMetaGenerator := state.GetMetaGen()
 	reslf := Core.ReintroduceMeta(&newMetaGenerator, index, state.GetN())
 	state.SetMetaGen(newMetaGenerator)
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Instantiate the formula : %s", reslf.ToString()) }),
 	)
 
@@ -202,8 +200,7 @@ func (nds *nonDestructiveSearch) instantiate(fatherId uint64, state *State, c Co
 			}
 		}
 		if !found {
-			Glob.PrintDebug(
-				"PS",
+			debug(
 				Lib.MkLazy(func() string {
 					return fmt.Sprintf(
 						"Error : No matching found for %v in new formula : %v\n",
@@ -245,16 +242,14 @@ func (nds *nonDestructiveSearch) instantiate(fatherId uint64, state *State, c Co
 	// 	}
 	// }
 
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Applied subst: %s",
 				state.GetAppliedSubst().GetSubst().ToString())
 		}),
 	)
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Real substitution applied : %s", new_subst.ToString())
@@ -302,7 +297,7 @@ func (nds *nonDestructiveSearch) manageSubstFoundNonDestructive(father_id uint64
 	}
 
 	choosenSubstMetas := new_choosen_subst.GetSubst().GetMeta()
-	Glob.PrintDebug("PS", Lib.MkLazy(func() string {
+	debug(Lib.MkLazy(func() string {
 		return fmt.Sprintf(
 			"Choosen subst : %v - HasInCommon : %v",
 			new_choosen_subst.GetSubst().ToString(),
@@ -312,8 +307,7 @@ func (nds *nonDestructiveSearch) manageSubstFoundNonDestructive(father_id uint64
 			),
 		)
 	}))
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("AreRulesApplicable : %v", st.AreRulesApplicable()) }),
 	)
 
@@ -321,8 +315,7 @@ func (nds *nonDestructiveSearch) manageSubstFoundNonDestructive(father_id uint64
 
 	// Catch all the meta which can be instantiate
 	form_to_instantiate = nds.catchFormulaToInstantiate(choosen_subst.GetSubst())
-	Glob.PrintDebug(
-		"PS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Form_to_instantiate : %v", form_to_instantiate) }),
 	)
 
@@ -403,8 +396,7 @@ func (ds *nonDestructiveSearch) manageResult(c Communication) (Core.Unifier, []P
 
 		time.Sleep(1 * time.Millisecond)
 
-		Glob.PrintDebug(
-			"MAIN",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("open is : %v from %v", open, res.getId()) }),
 		)
 		Glob.PrintInfo("MAIN", fmt.Sprintf("%v goroutines still running - %v goroutines generated", runtime.NumGoroutine(), Glob.GetNbGoroutines()))

--- a/src/Search/rules.go
+++ b/src/Search/rules.go
@@ -71,7 +71,7 @@ var strToPrintMap map[string]string = map[string]string{
 *	a substitution, the substitution which make the contradiction (possibly empty)
 **/
 func ApplyClosureRules(form AST.Form, state *State) (result bool, substitutions []Unif.Substitutions) {
-	Glob.PrintDebug("ACR", Lib.MkLazy(func() string { return "Start ACR" }))
+	debug(Lib.MkLazy(func() string { return "Start ACR" }))
 
 	if searchObviousClosureRule(form) {
 		return true, substitutions
@@ -88,10 +88,10 @@ func ApplyClosureRules(form AST.Form, state *State) (result bool, substitutions 
 	substFound, matchSubsts := searchClosureRule(f, *state)
 
 	if substFound {
-		Glob.PrintDebug("ACR", Lib.MkLazy(func() string { return "Subst found" }))
+		debug(Lib.MkLazy(func() string { return "Subst found" }))
 
 		for _, subst := range matchSubsts {
-			Glob.PrintDebug("ACR", Lib.MkLazy(func() string { return fmt.Sprintf("MSL : %v", subst.ToString()) }))
+			debug(Lib.MkLazy(func() string { return fmt.Sprintf("MSL : %v", subst.ToString()) }))
 
 			if subst.GetSubst().Equals(Unif.MakeEmptySubstitution()) {
 				result = true
@@ -102,8 +102,7 @@ func ApplyClosureRules(form AST.Form, state *State) (result bool, substitutions 
 			}
 
 			if result {
-				Glob.PrintDebug(
-					"ACR",
+				debug(
 					Lib.MkLazy(func() string {
 						return fmt.Sprintf(
 							"Subst found between : %v and %v : %v",
@@ -138,12 +137,12 @@ func searchForbidden(state *State, s Unif.MatchingSubstitutions) bool {
 func searchObviousClosureRule(f AST.Form) bool {
 	switch nf := f.(type) {
 	case AST.Bot:
-		Glob.PrintDebug("AR", Lib.MkLazy(func() string { return "⊥ found !" }))
+		debug(Lib.MkLazy(func() string { return "⊥ found !" }))
 		return true
 	case AST.Not:
 		switch nf.GetForm().(type) {
 		case AST.Top:
-			Glob.PrintDebug("AR", Lib.MkLazy(func() string { return "¬⊤ found !" }))
+			debug(Lib.MkLazy(func() string { return "¬⊤ found !" }))
 			return true
 		default:
 			return false
@@ -161,8 +160,7 @@ func searchInequalities(form AST.Form) (bool, Unif.Substitutions) {
 		if predNeq, isPred := formNot.GetForm().(AST.Pred); isPred {
 			if predNeq.GetID().Equals(AST.Id_eq) {
 
-				Glob.PrintDebug(
-					"SI",
+				debug(
 					Lib.MkLazy(func() string {
 						return fmt.Sprintf(
 							"Search Inequality closure rule : %v",
@@ -174,18 +172,15 @@ func searchInequalities(form AST.Form) (bool, Unif.Substitutions) {
 				arg_1 := predNeq.GetArgs().At(0)
 				arg_2 := predNeq.GetArgs().At(1)
 
-				Glob.PrintDebug(
-					"SI",
+				debug(
 					Lib.MkLazy(func() string { return fmt.Sprintf("Arg 1 : %v", arg_1.ToString()) }),
 				)
-				Glob.PrintDebug(
-					"SI",
+				debug(
 					Lib.MkLazy(func() string { return fmt.Sprintf("Arg 2 : %v", arg_2.ToString()) }),
 				)
 
 				subst = Unif.AddUnification(arg_1, arg_2, subst)
-				Glob.PrintDebug(
-					"SI",
+				debug(
 					Lib.MkLazy(func() string { return fmt.Sprintf("Subst : %v", subst.ToString()) }),
 				)
 
@@ -225,7 +220,7 @@ func setStateRules(state *State, name string, forms ...string) {
 		strWords += "_" + val
 	}
 
-	Glob.PrintDebug("AR", Lib.MkLazy(func() string { return "Applying " + strChars + "..." }))
+	debug(Lib.MkLazy(func() string { return "Applying " + strChars + "..." }))
 
 	state.SetCurrentProofRule(strChars)
 	state.SetCurrentProofRuleName(strWords)

--- a/src/Search/search.go
+++ b/src/Search/search.go
@@ -56,6 +56,12 @@ var UsedSearch SearchAlgorithm
 
 var EagerEq = false
 
+var debug Glob.Debugger
+
+func InitDebugger() {
+	debug = Glob.CreateDebugger("search")
+}
+
 func init() {
 	SetSearchAlgorithm(NewDestructiveSearch())
 }
@@ -70,9 +76,8 @@ func SetApplyRules(function func(uint64, State, Communication, Core.FormAndTerms
 
 /* Begin the proof search */
 func Search(formula AST.Form, bound int) {
-	Glob.PrintDebug("MAIN", Lib.MkLazy(func() string { return "Start search" }))
-	Glob.PrintDebug(
-		"MAIN",
+	debug(Lib.MkLazy(func() string { return "Start search" }))
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Initial formula: %v", formula.ToString()) }),
 	)
 

--- a/src/Search/state.go
+++ b/src/Search/state.go
@@ -292,69 +292,66 @@ func MakeState(limit int, tp, tn Unif.DataStructure, f AST.Form) State {
 
 /* Print a state */
 func (st State) Print() {
-	Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "==== State ====" }))
-	Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return fmt.Sprintf(" n = %v", st.GetN()) }))
+	debug(Lib.MkLazy(func() string { return "==== State ====" }))
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf(" n = %v", st.GetN()) }))
 
 	if !st.GetLF().IsEmpty() {
-		Glob.PrintDebug("Pst", Lib.MkLazy(func() string { return "Formulas list: " }))
+		debug(Lib.MkLazy(func() string { return "Formulas list: " }))
 		st.GetLF().Print()
 	}
 
 	if !st.GetAtomic().IsEmpty() {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Atomic formulas: " }))
+		debug(Lib.MkLazy(func() string { return "Atomic formulas: " }))
 		st.GetAtomic().Print()
 	}
 
 	if !st.GetAlpha().IsEmpty() {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Alpha formulas: " }))
+		debug(Lib.MkLazy(func() string { return "Alpha formulas: " }))
 		st.GetAlpha().Print()
 	}
 
 	if !st.GetBeta().IsEmpty() {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Beta formulas: " }))
+		debug(Lib.MkLazy(func() string { return "Beta formulas: " }))
 		st.GetBeta().Print()
 	}
 
 	if !st.GetDelta().IsEmpty() {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Delta formulas: " }))
+		debug(Lib.MkLazy(func() string { return "Delta formulas: " }))
 		st.GetDelta().Print()
 	}
 
 	if !st.GetGamma().IsEmpty() {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Gamma formulas: " }))
+		debug(Lib.MkLazy(func() string { return "Gamma formulas: " }))
 		st.GetGamma().Print()
 	}
 
 	if len(st.GetMetaGen()) > 0 {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Meta generator formulas: " }))
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return Core.MetaGenListToString(st.GetMetaGen()) }))
+		debug(Lib.MkLazy(func() string { return "Meta generator formulas: " }))
+		debug(Lib.MkLazy(func() string { return Core.MetaGenListToString(st.GetMetaGen()) }))
 	}
 
 	if !st.GetMM().IsEmpty() {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Meta Mother: " }))
-		Glob.PrintDebug(
-			"Pst",
+		debug(Lib.MkLazy(func() string { return "Meta Mother: " }))
+		debug(
 			Lib.MkLazy(func() string { return Lib.ListToString(st.GetMM().Elements(), ",", "[]") }),
 		)
 	}
 
 	if !st.GetMC().IsEmpty() {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Meta current: " }))
-		Glob.PrintDebug(
-			"Pst",
+		debug(Lib.MkLazy(func() string { return "Meta current: " }))
+		debug(
 			Lib.MkLazy(func() string { return Lib.ListToString(st.GetMC().Elements(), ",", "[]") }),
 		)
 	}
 
 	if !st.GetAppliedSubst().IsEmpty() {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Applied subst: " }))
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return st.GetAppliedSubst().ToString() }))
+		debug(Lib.MkLazy(func() string { return "Applied subst: " }))
+		debug(Lib.MkLazy(func() string { return st.GetAppliedSubst().ToString() }))
 	}
 
 	if len(st.GetSubstsFound()) > 0 {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Subst_found: " }))
-		Glob.PrintDebug(
-			"PSt",
+		debug(Lib.MkLazy(func() string { return "Subst_found: " }))
+		debug(
 			Lib.MkLazy(func() string {
 				return Unif.SubstListToString(Core.GetSubstListFromSubstAndFormList(st.GetSubstsFound()))
 			}),
@@ -362,17 +359,16 @@ func (st State) Print() {
 	}
 
 	if !st.GetLastAppliedSubst().IsEmpty() {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Last applied subst:" }))
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return st.GetLastAppliedSubst().ToString() }))
+		debug(Lib.MkLazy(func() string { return "Last applied subst:" }))
+		debug(Lib.MkLazy(func() string { return st.GetLastAppliedSubst().ToString() }))
 	}
 
 	if len(st.forbidden) > 0 {
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return "Forbidden:" }))
-		Glob.PrintDebug("PSt", Lib.MkLazy(func() string { return Unif.SubstListToString(st.forbidden) }))
+		debug(Lib.MkLazy(func() string { return "Forbidden:" }))
+		debug(Lib.MkLazy(func() string { return Unif.SubstListToString(st.forbidden) }))
 	}
 
-	Glob.PrintDebug(
-		"PSt",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("BT on formulas : %v", st.GetBTOnFormulas()) }),
 	)
 
@@ -465,9 +461,8 @@ func (st State) AreRulesApplicable() bool {
 
 /* Put the given formula in the right rule box in the given state */
 func (st *State) DispatchForm(f Core.FormAndTerms) {
-	Glob.PrintDebug("DF", Lib.MkLazy(func() string { return fmt.Sprintf("Dispatch the form : %v ", f.ToString()) }))
-	Glob.PrintDebug(
-		"DF",
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf("Dispatch the form : %v ", f.ToString()) }))
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Kind of rule : %v ", Core.ShowKindOfRule(f.GetForm())) }),
 	)
 	switch Core.ShowKindOfRule(f.GetForm()) {

--- a/src/Typing/term_rules.go
+++ b/src/Typing/term_rules.go
@@ -36,7 +36,6 @@ import (
 	"fmt"
 
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 )
 
@@ -152,7 +151,7 @@ func getArgsTypes(
 			types = append(types, tmpTerm.GetTypeApp())
 		// There shouldn't be Metas yet.
 		case AST.Meta:
-			Glob.PrintDebug("GAT", Lib.MkLazy(func() string { return "Found a Meta while typing everything." }))
+			debug(Lib.MkLazy(func() string { return "Found a Meta while typing everything." }))
 			// ID is filtered out
 		}
 	}

--- a/src/Typing/type.go
+++ b/src/Typing/type.go
@@ -38,6 +38,12 @@ import (
 	"github.com/GoelandProver/Goeland/Lib"
 )
 
+var debug Glob.Debugger
+
+func InitDebugger() {
+	debug = Glob.CreateDebugger("typing")
+}
+
 /**
  * This file implements a second pass on the given formula to:
  *	- Type the variables

--- a/src/Unif/code-trees.go
+++ b/src/Unif/code-trees.go
@@ -40,7 +40,6 @@ import (
 	"strings"
 
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 )
 
@@ -191,7 +190,7 @@ func (n Node) printAux(tab int) {
 		if instr.IsEquivalent(Begin{}) {
 			tab += 1
 		}
-		Glob.PrintDebug("PT", Lib.MkLazy(func() string { return strings.Repeat("\t", tab) + instr.ToString() }))
+		debug(Lib.MkLazy(func() string { return strings.Repeat("\t", tab) + instr.ToString() }))
 
 		if IsEnd(instr) {
 			tab -= 1
@@ -200,10 +199,10 @@ func (n Node) printAux(tab int) {
 
 	if n.isLeaf() {
 		for _, form := range n.formulae.Slice() {
-			Glob.PrintDebug("PT", Lib.MkLazy(func() string { return strings.Repeat("\t", tab+1) + form.ToString() }))
+			debug(Lib.MkLazy(func() string { return strings.Repeat("\t", tab+1) + form.ToString() }))
 		}
 	}
-	Glob.PrintDebug("PT", Lib.MkLazy(func() string { return "\n" }))
+	debug(Lib.MkLazy(func() string { return "\n" }))
 
 	// For each child, print the following sequences with tab = tab + 1
 	for _, child := range n.children {

--- a/src/Unif/matching.go
+++ b/src/Unif/matching.go
@@ -45,6 +45,12 @@ import (
 	"github.com/GoelandProver/Goeland/Lib"
 )
 
+var debug Glob.Debugger
+
+func InitDebugger() {
+	debug = Glob.CreateDebugger("unif")
+}
+
 /*** Unify ***/
 
 /* Helper function to avoid using MakeMachine() outside of this file. */
@@ -94,22 +100,15 @@ func (m *Machine) unify(node Node, formula AST.Form) []MatchingSubstitutions {
 func (m *Machine) unifyAux(node Node) []MatchingSubstitutions {
 	for _, instr := range node.value {
 
-		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return "------------------------" }))
-		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("Instr: %v", instr.ToString()) }))
-		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("Meta : %v", m.meta.ToString()) }))
-		Glob.PrintDebug(
-			"UX",
-			Lib.MkLazy(func() string { return fmt.Sprintf("Subst : %v", SubstPairListToString(m.subst)) }),
-		)
-		Glob.PrintDebug(
-			"UX",
-			Lib.MkLazy(func() string { return fmt.Sprintf("Post : %v", IntPairistToString(m.post)) }),
-		)
-		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("IsLocked : %v", m.isLocked()) }))
-		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("HasPushed : %v", m.hasPushed) }))
-		Glob.PrintDebug("UX", Lib.MkLazy(func() string { return fmt.Sprintf("HasPoped : %v", m.hasPoped) }))
-		Glob.PrintDebug(
-			"UX",
+		debug(Lib.MkLazy(func() string { return "------------------------" }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("Instr: %v", instr.ToString()) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("Meta : %v", m.meta.ToString()) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("Subst : %v", SubstPairListToString(m.subst)) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("Post : %v", IntPairistToString(m.post)) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("IsLocked : %v", m.isLocked()) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("HasPushed : %v", m.hasPushed) }))
+		debug(Lib.MkLazy(func() string { return fmt.Sprintf("HasPoped : %v", m.hasPoped) }))
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"m.beginCount: %v - m.beginLock : %v",
@@ -117,8 +116,7 @@ func (m *Machine) unifyAux(node Node) []MatchingSubstitutions {
 					m.beginLock)
 			}),
 		)
-		Glob.PrintDebug(
-			"UX",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"m.TopLevelCount: %v - m.TopLevelTot : %v",
@@ -126,16 +124,13 @@ func (m *Machine) unifyAux(node Node) []MatchingSubstitutions {
 					m.topLevelTot)
 			}),
 		)
-		Glob.PrintDebug(
-			"UX",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Cursor: %v/%v", m.q, m.terms.Len()) }),
 		)
-		Glob.PrintDebug(
-			"UX",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("m.terms[cursor] : %v", m.terms.At(m.q).ToString()) }),
 		)
-		Glob.PrintDebug(
-			"UX",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"m.terms : %v",
@@ -195,21 +190,19 @@ func (m *Machine) unifyAux(node Node) []MatchingSubstitutions {
 /* Unify on goroutines - to manage die message */
 /* TODO : remove when debug ok */
 func (m *Machine) unifyAuxOnGoroutine(n Node, ch chan []MatchingSubstitutions, father_id uint64) {
-	Glob.PrintDebug(
-		"UA",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Child of %v, Unify Aux", father_id) }),
 	)
 	subs := m.unifyAux(n)
 	ch <- subs
-	Glob.PrintDebug("UA", Lib.MkLazy(func() string { return "Die" }))
+	debug(Lib.MkLazy(func() string { return "Die" }))
 }
 
 /* Launches each child of the current node in a goroutine. */
 func (m *Machine) launchChildrenSearch(node Node) []MatchingSubstitutions {
 	channels := []chan []MatchingSubstitutions{}
 	for _, c := range node.children {
-		Glob.PrintDebug(
-			"LCS",
+		debug(
 			Lib.MkLazy(func() string { return fmt.Sprintf("Next symbol = %v", c.getValue()[0].ToString()) }),
 		)
 		channels = append(channels, make(chan []MatchingSubstitutions))

--- a/src/Unif/matching_substitutions.go
+++ b/src/Unif/matching_substitutions.go
@@ -40,7 +40,6 @@ import (
 	"fmt"
 
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 )
 
@@ -61,7 +60,7 @@ func (m MatchingSubstitutions) ToString() string {
 }
 
 func (m MatchingSubstitutions) Print() {
-	Glob.PrintDebug("M.P", Lib.MkLazy(func() string { return fmt.Sprintf(" %s ", m.GetForm().ToString()) }))
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf(" %s ", m.GetForm().ToString()) }))
 	m.GetSubst().Print()
 }
 

--- a/src/Unif/substitutions_tree.go
+++ b/src/Unif/substitutions_tree.go
@@ -40,7 +40,6 @@ import (
 	"fmt"
 
 	"github.com/GoelandProver/Goeland/AST"
-	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 )
 
@@ -51,8 +50,7 @@ import (
 * Merge both of them
 **/
 func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.Form) Substitutions {
-	Glob.PrintDebug(
-		"CS",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Compute substitution : %v and %v",
@@ -76,8 +74,7 @@ func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.
 	for _, value := range subs {
 		currentMeta := metasFromTreeForm.At(value.GetIndex())
 		currentValue := value.GetTerm()
-		Glob.PrintDebug(
-			"CS",
+		debug(
 			Lib.MkLazy(func() string {
 				return fmt.Sprintf(
 					"Iterate on subst : %v and  %v",
@@ -105,8 +102,7 @@ func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.
 		}
 	}
 
-	Glob.PrintDebug(
-		"CS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("before meta : %v", metasToSubs.ToString()) }),
 	)
 	// Metas_subst eliminate
@@ -115,12 +111,9 @@ func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.
 	if metasToSubs.Equals(Failure()) {
 		return Failure()
 	}
-	Glob.PrintDebug(
-		"CS", Lib.MkLazy(func() string { return fmt.Sprintf("After meta : %v", metasToSubs.ToString()) }),
-	)
+	debug(Lib.MkLazy(func() string { return fmt.Sprintf("After meta : %v", metasToSubs.ToString()) }))
 
-	Glob.PrintDebug(
-		"CS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("before tree_subst : %v", treeSubs.ToString()) }),
 	)
 	// Tree subst elminate
@@ -129,8 +122,7 @@ func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.
 	if treeSubs.Equals(Failure()) {
 		return Failure()
 	}
-	Glob.PrintDebug(
-		"CS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("after tree_subst : %v", treeSubs.ToString()) }),
 	)
 
@@ -139,15 +131,15 @@ func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.
 	if res.Equals(Failure()) {
 		return res
 	}
-	Glob.PrintDebug(
-		"CS",
+
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("after merge : %v", res.ToString()) }),
 	)
 
 	EliminateMeta(&res)
 	Eliminate(&res)
-	Glob.PrintDebug(
-		"CS",
+
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("after eliminate : %v", res.ToString()) }),
 	)
 
@@ -156,8 +148,7 @@ func computeSubstitutions(subs []SubstPair, metasToSubs Substitutions, form AST.
 
 /* Call addUnification and returns a status - modify m.meta */
 func (m *Machine) trySubstituteMeta(i AST.Term, j AST.Term) Status {
-	Glob.PrintDebug(
-		"TS",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Try substitute : %v and %v", i.ToString(), j.ToString()) }),
 	)
 	new_meta := AddUnification(i, j, m.meta.Copy())
@@ -169,8 +160,7 @@ func (m *Machine) trySubstituteMeta(i AST.Term, j AST.Term) Status {
 }
 
 func AddUnification(term1, term2 AST.Term, subst Substitutions) Substitutions {
-	Glob.PrintDebug(
-		"AU",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Add unification : %v and %v to %v",
@@ -212,8 +202,7 @@ func AddUnification(term1, term2 AST.Term, subst Substitutions) Substitutions {
 
 /* Adds the unifications found to the meta substitutions from running the algorithm on term1 and term2. */
 func (m *Machine) addUnifications(term1, term2 AST.Term) Status {
-	Glob.PrintDebug(
-		"au",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"add unification : %v and %v",
@@ -236,8 +225,7 @@ func (m *Machine) addUnifications(term1, term2 AST.Term) Status {
 
 /* Tries to unify term1 with term2, depending on the substitutions already found by the parent unification process. */
 func tryUnification(term1, term2 AST.Term, meta Substitutions) []MatchingSubstitutions {
-	Glob.PrintDebug(
-		"TU",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Try unification : %v and %v",
@@ -257,8 +245,7 @@ func tryUnification(term1, term2 AST.Term, meta Substitutions) []MatchingSubstit
 
 /* Merge two valid substitutions */
 func MergeSubstitutions(s1, s2 Substitutions) (Substitutions, bool) {
-	Glob.PrintDebug(
-		"MS",
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Merge substitution : %v and %v",

--- a/src/Unif/substitutions_type.go
+++ b/src/Unif/substitutions_type.go
@@ -61,8 +61,7 @@ func (s Substitutions) ToStringForProof() string {
 
 /* Helper function, prints the content of a Substitutions object. */
 func (s Substitutions) Print() {
-	Glob.PrintDebug(
-		"Print",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Success. %v ", s.ToString()) }),
 	)
 }
@@ -246,8 +245,7 @@ func isRecursive(t AST.Term, m AST.Meta) bool {
 	case AST.Meta:
 		return t.Equals(m)
 	default:
-		Glob.PrintDebug(
-			"IR",
+		debug(
 			Lib.MkLazy(func() string { return "Error: [[substitution.go:157]] shouldn't be attained." }),
 		)
 	}
@@ -383,8 +381,7 @@ func eliminateList(
 
 /* Eliminates one of the subsitution of a pair like (X, Y) (Y, X). It will keep the first one indexed in the map. */
 func EliminateMeta(subst *Substitutions) {
-	Glob.PrintDebug(
-		"EM",
+	debug(
 		Lib.MkLazy(func() string { return fmt.Sprintf("Eliminate Meta on %v", subst.ToString()) }),
 	)
 	meta := Substitutions{}

--- a/src/main.go
+++ b/src/main.go
@@ -54,13 +54,17 @@ import (
 	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Mods/assisted"
 	"github.com/GoelandProver/Goeland/Mods/dmt"
+	equality "github.com/GoelandProver/Goeland/Mods/equality/bse"
 	"github.com/GoelandProver/Goeland/Parser"
 	"github.com/GoelandProver/Goeland/Search"
+	"github.com/GoelandProver/Goeland/Search/incremental"
 	"github.com/GoelandProver/Goeland/Typing"
+	"github.com/GoelandProver/Goeland/Unif"
 )
 
 var chAssistant chan bool = make(chan bool)
 var main_label = "Main"
+var debug Glob.Debugger
 
 func printChrono(id string, start time.Time) {
 	fmt.Printf("%s Chrono - %s - %d\n", "%", id, time.Since(start).Milliseconds())
@@ -96,7 +100,7 @@ func main() {
 
 // Start solving
 func startSearch(form AST.Form, bound int) {
-	Glob.PrintDebug(main_label, Lib.MkLazy(func() string { return "Start search" }))
+	debug(Lib.MkLazy(func() string { return "Start search" }))
 
 	// FIXME: assisted should be a plugin.
 	// Ideally, we should create a hook here in order to let plugins do what
@@ -128,8 +132,7 @@ func presearchLoader() (AST.Form, int) {
 	statements, bound, containsEquality := Parser.ParseTPTPFile(problem)
 	actualStatements := Engine.ToInternalSyntax(statements)
 
-	Glob.PrintDebug(
-		main_label,
+	debug(
 		Lib.MkLazy(func() string {
 			return fmt.Sprintf(
 				"Statement : %s", Core.StatementListToString(actualStatements))
@@ -175,13 +178,28 @@ func doMemProfile() {
 /* Initializes the options, the loggers and some other Glob variables*/
 func initEverything() {
 	Glob.SetStart(time.Now())
+	// Always init logs before debuggers
 	Glob.InitLogs()
+	// Always init debuggers before options
+	initDebuggers()
 	initOpts()
 	runtime.GOMAXPROCS(Glob.GetCoreLimit())
 	AST.Init()
 }
 
-// FIXME: eventually, we would want to add an "interpretation" layer between elab and internal representation that does this
+func initDebuggers() {
+	debug = Glob.CreateDebugger(main_label)
+	assisted.InitDebugger()
+	AST.InitDebugger()
+	Core.InitDebugger()
+	dmt.InitDebugger()
+	equality.InitDebugger()
+	incremental.InitDebugger()
+	Search.InitDebugger()
+	Typing.InitDebugger()
+	Unif.InitDebugger()
+}
+
 func StatementListToFormula(statements []Core.Statement, old_bound int, problemDir string) (form AST.Form, bound int, containsEquality bool) {
 	and_list := AST.NewFormList()
 	var not_form AST.Form
@@ -193,10 +211,7 @@ func StatementListToFormula(statements []Core.Statement, old_bound int, problemD
 			file_name := statement.GetName()
 
 			realname, err := getFile(file_name, problemDir)
-			Glob.PrintDebug(
-				main_label,
-				Lib.MkLazy(func() string { return fmt.Sprintf("File to parse : %s\n", realname) }),
-			)
+			debug(Lib.MkLazy(func() string { return fmt.Sprintf("File to parse : %s\n", realname) }))
 
 			if err != nil {
 				Glob.PrintError(main_label, err.Error())

--- a/src/options.go
+++ b/src/options.go
@@ -108,7 +108,7 @@ func buildOptions() {
 	(&option[string]{}).init(
 		"debug",
 		"none",
-		"Enables printing debug information in the terminal. Debugging a specific part of the code is possible via -debug a,b,c which will output the debugs of parts a, b and c. If you want all the debugs, use -debug all or simply -debug.",
+		"Enables printing debug information in the terminal. Debugging a specific part of the code is possible via -debug a,b,c which will output the debugs of parts a, b and c. If you want all the debugs, use -debug all.",
 		Glob.SetDebug,
 		func(string) {})
 	(&option[bool]{}).init(

--- a/src/options.go
+++ b/src/options.go
@@ -105,15 +105,12 @@ func initOpts() {
 *  funcAlways func(T): a function that will always be run. The parameter will be the value of the option.
 **/
 func buildOptions() {
-	(&option[bool]{}).init(
+	(&option[string]{}).init(
 		"debug",
-		false,
-		"Enables printing debug information in the terminal",
-		func(bool) {
-			Glob.SetDebug(true)
-			Glob.EnableDebug()
-		},
-		func(bool) {})
+		"none",
+		"Enables printing debug information in the terminal. Debugging a specific part of the code is possible via -debug a,b,c which will output the debugs of parts a, b and c. If you want all the debugs, use -debug all or simply -debug.",
+		Glob.SetDebug,
+		func(string) {})
 	(&option[bool]{}).init(
 		"silent",
 		false,


### PR DESCRIPTION
Somewhat addresses #25, even though not yet with levels.

# Description

Instead of calling `PrintDebug` with a function name that could get outdated information (e.g., the "MAIN" label for functions inside the Search folder), we introduce "debuggers". Debuggers are local to a folder (except if they are exported, but it's not the goal here), e.g., the AST folder gets its AST debugger, the Search folder gets its Search debugger and so on. A debugger can be created as follows:
```go
debug := Glob.CreateDebug(name)
```
They must be initialized *before* initializing the options in order to be selectable via command line (e.g., `-debug AST,search` or `-debug all`). If a debugger does not exist, the user gets informed by a warning.

It then allows for a more fine-grained approach to debugging, only focusing on a special section instead of getting all the debug information (where some might not be useful). For instance, when debugging the unification, `-debug unif` suffices to get what we want.

We could imagine an even more stratified system (e.g., with subdebuggers or debug levels) but I think it's a good first step.

# PR dependencies

* #48 
