### PR TITLE
Fix outdated option `-ocoq` and modernize presearch information messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ pp. 359-368, 2022.
 * The following paper presents an algorithm for deskolemizing proofs, which
   introduces a compatibility layer between tableaux and sequent calculus and
   then allows us to certify the proofs in various proof assistants. Goéland
-  currently outputs proofs for Rocq (`-ocoq`) and LambdaPi (`-olp`). Note that
+  currently outputs proofs for Rocq (`-orocq`) and LambdaPi (`-olp`). Note that
   the implementation is currently outdated w.r.t. the paper's version.
 
   [RBCH24] Johann Rosain, Richard Bonichon, Julie Cailler and Olivier Hermant,

--- a/USAGE.md
+++ b/USAGE.md
@@ -31,7 +31,7 @@ The most commonly used options of Goéland are the following ones.
 | -dmt | Enables deduction modulo theory. |
 | -dmt_before_eq | Enables dmt rewriting-steps before equality. |
 | -eagereq | Run equality reasoning every time a new (in)equality is added to the branch. |
-| -flatten | Flattens AND and OR formulas. Incompatible with `-ocoq`, `-osctptp`, `-olp`. |
+| -flatten | Flattens AND and OR formulas. Incompatible with `-orocq`, `-osctptp`, `-olp`. |
 | -h | Displays the help text with all the options. |
 | -incr | Enables the incremental search algorithm. |
 | -increq | Run equality reasoning incrementally. |
@@ -50,9 +50,9 @@ Goéland has multiple proof outputs:
 
 | Parameter flag | Effect |
 |--------------------------|-----------|
-| -chrono | Should only be used with the `-ocoq` or the `-olp` parameters. Enables the chronometer for deskolemization and proof translation. |
-| -context | Get the current proof system prelude. Only outputs something if paired with the `-ocoq` or the `-olp` parameters. |
-| -ocoq | Enables the Coq format for proofs instead of text. |
+| -chrono | Should only be used with the `-orocq` or the `-olp` parameters. Enables the chronometer for deskolemization and proof translation. |
+| -context | Get the current proof system prelude. Only outputs something if paired with the `-orocq` or the `-olp` parameters. |
+| -orocq | Enables the Rocq format for proofs instead of text. |
 | -olp | Enables the Lambdapi format for proofs instead of text. |
 | -otptp | Enables the TPTP format for proofs instead of text. |
 | -osctptp | Enables the SC-TPTP format for proofs instead of text. |

--- a/devtools/run_proofs_tests.py
+++ b/devtools/run_proofs_tests.py
@@ -7,7 +7,7 @@ def Out(command):
     result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True, encoding='utf-8')
     return result.stdout
 
-def LaunchTest(prover_name, command_line, iscoq, success, file, outdir, memory_limit=None, failure=None):
+def LaunchTest(prover_name, command_line, isrocq, success, file, outdir, memory_limit=None, failure=None):
     output = Out(command_line).encode('utf-8', errors='ignore').decode(errors='ignore')
     res = 0
 
@@ -20,7 +20,7 @@ def LaunchTest(prover_name, command_line, iscoq, success, file, outdir, memory_l
         with open(outdir + "/" + file + ".proof", "w") as f:
             write = False
             for i, line in enumerate(output.split("\n")) :
-                if "% Start Coq proof." in line :
+                if "% Start Rocq proof." in line :
                     write = False
                     lines = output.split("\n")[i+1:]
                 if write :
@@ -34,10 +34,10 @@ def LaunchTest(prover_name, command_line, iscoq, success, file, outdir, memory_l
                     write = False
                 if write :
                     f.write(line + "\n")
-        if iscoq:
-            coq_output = run(f"coqc -vok {outdir}/{file}.v", stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True, encoding='utf-8').stderr
-            if "Error" in coq_output:
-                print("A proof has been output but it's not a valid coq proof.")
+        if isrocq:
+            rocq_output = run(f"rocq compile -vok {outdir}/{file}.v", stdout=PIPE, stderr=PIPE, universal_newlines=True, shell=True, encoding='utf-8').stderr
+            if "Error" in rocq_output:
+                print("A proof has been output but it's not a valid rocq proof.")
                 res = 2
     else:
         if re.search("panic", output) :
@@ -49,7 +49,7 @@ def LaunchTest(prover_name, command_line, iscoq, success, file, outdir, memory_l
     return res
 
 if len(sys.argv) < 6: 
-    print(f"python3 {sys.argv[0]} exec problem_folder timeout outdir coq goeland_options")
+    print(f"python3 {sys.argv[0]} exec problem_folder timeout outdir rocq goeland_options")
 
 else:
     exe = sys.argv[1]
@@ -62,12 +62,12 @@ else:
     outdir  = sys.argv[4]
 
     opt = int(sys.argv[5])
-    iscoq = False
+    isrocq = False
     compare = False
     proofOptions = ""
     if opt > 0 :
-        iscoq = True
-        proofOptions = "-ocoq -context"
+        isrocq = True
+        proofOptions = "-orocq -context"
         if opt == 2:
             proofOptions += " -compare"
     else :
@@ -89,7 +89,7 @@ else:
         res = LaunchTest(
             "Goéland", 
             f"timeout {timeout} {exe} {proofOptions} {args} {folder+file}", 
-            iscoq, 
+            isrocq,
             "% RES : VALID", 
             file, 
             outdir, 

--- a/devtools/stats_proof_size.py
+++ b/devtools/stats_proof_size.py
@@ -5,7 +5,7 @@ if len(sys.argv) != 3:
 
 class Branches:
     def __init__(self):
-        self.coq = -1
+        self.rocq = -1
         self.prf = -1
 
     def __str__(self):
@@ -13,11 +13,11 @@ class Branches:
         if self.prf != -1:
             s += str(self.prf)
         s += ";"
-        if self.coq != -1:
-            s += str(self.coq)
+        if self.rocq != -1:
+            s += str(self.rocq)
         s += ";"
-        if self.prf != -1 and self.coq != -1 :
-            s += str(self.coq/self.prf)
+        if self.prf != -1 and self.rocq != -1 :
+            s += str(self.rocq/self.prf)
         return s + "\n"
 
 folder = sys.argv[1]
@@ -35,17 +35,17 @@ for _, file in enumerate(entries) :
                 if "auto." in line or "congruence." in line or "CLOSURE" in line :
                     count += 1
             if file.endswith(".v") :
-                res[k].coq = count
+                res[k].rocq = count
             else :
                 res[k].prf = count
 
 with open(outfile, "w") as f :
-    f.write(";Proof;Coq;Proof Size Increase\n")
+    f.write(";Proof;Rocq;Proof Size Increase\n")
     totalIncrease = 0
     maxSizeIncrease = 0
     for file, c in res.items() :
         f.write(f"{file};{str(c)}")
-        totalIncrease += c.coq/c.prf
-        maxSizeIncrease = max(maxSizeIncrease, c.coq/c.prf)
+        totalIncrease += c.rocq/c.prf
+        maxSizeIncrease = max(maxSizeIncrease, c.rocq/c.prf)
     f.write(f"\n;Average Size Increase;;{totalIncrease/len(res)}\n")
     f.write(f";Max Size Increase;;{maxSizeIncrease}")

--- a/src/AST/quantifiers.go
+++ b/src/AST/quantifiers.go
@@ -133,7 +133,7 @@ func (q quantifier) ToMappedStringSurround(mapping MapString, displayTypes bool)
 	for _, vt := range varsType {
 		str := mapping[QuantVarOpen]
 		str += ListToMappedString(q.GetVarList(), varSeparator, "", mapping, false)
-		if displayTypes || Glob.IsCoqOutput() {
+		if displayTypes || Glob.IsRocqOutput() {
 			str += " : " + vt.type_.ToString()
 		}
 		varStrings = append(varStrings, str+mapping[QuantVarClose])

--- a/src/Glob/helper.go
+++ b/src/Glob/helper.go
@@ -48,7 +48,7 @@ import (
 	"time"
 )
 
-var ocoq = false
+var orocq = false
 var olambdapi = false
 var otptp = false
 var osctptp = false
@@ -206,8 +206,8 @@ func IsPrettyPrint() bool {
 	return prettyPrint
 }
 
-func IsCoqOutput() bool {
-	return ocoq
+func IsRocqOutput() bool {
+	return orocq
 }
 
 func IsLambdapiOutput() bool {
@@ -356,8 +356,8 @@ func DisplayPretty() {
 	prettyPrint = true
 }
 
-func OutputCoq() {
-	ocoq = true
+func OutputRocq() {
+	orocq = true
 }
 
 func OutputLambdapi() {

--- a/src/Glob/log.go
+++ b/src/Glob/log.go
@@ -106,9 +106,9 @@ var printToLogger = func(logger *log.Logger, function, message string) {
 	toParse += additionalStr
 
 	options = append(options, function)
-	toParse += "[%v]"
+	toParse += "[%s]"
 
-	toParse += " %v\n"
+	toParse += " %s\n"
 	options = append(options, message)
 	logger.Output(3, fmt.Sprintf(toParse, options...))
 }

--- a/src/Mods/lambdapi/output.go
+++ b/src/Mods/lambdapi/output.go
@@ -68,8 +68,8 @@ var LambdapiOutputProofStruct = &Search.OutputProofStruct{ProofOutput: MakeLambd
 // Plugin initialisation and main function to call.
 
 // Section: init
-// Functions: MakeCoqOutput
-// Main functions of the coq module.
+// Functions: MakeRocqOutput
+// Main functions of the rocq module.
 // TODO:
 //	* Write the context for TFF problems
 

--- a/src/Mods/rocq/context.go
+++ b/src/Mods/rocq/context.go
@@ -31,10 +31,10 @@
 **/
 
 /**
-* This file provides coq's context for a proof.
+* This file provides rocq's context for a proof.
 **/
 
-package coq
+package rocq
 
 import (
 	"fmt"
@@ -119,7 +119,8 @@ func getContextFromFormula(root AST.Form) []string {
 		result = clean(result, getContextFromFormula(nf.GetForm()))
 	case AST.Pred:
 		if !nf.GetID().Equals(AST.Id_eq) {
-			result = append(result, mapDefault(fmt.Sprintf("Parameter %s : %s.", nf.GetID().ToMappedString(coqMapConnectors(), false), nf.GetType().ToString())))
+			result = append(result, mapDefault(fmt.Sprintf("Parameter %s : %s.",
+				nf.GetID().ToMappedString(rocqMapConnectors(), false), nf.GetType().ToString())))
 		}
 		for _, term := range nf.GetArgs().GetSlice() {
 			result = append(result, clean(result, getContextFromTerm(term))...)
@@ -131,7 +132,8 @@ func getContextFromFormula(root AST.Form) []string {
 func getContextFromTerm(trm AST.Term) []string {
 	result := []string{}
 	if fun, isFun := trm.(AST.Fun); isFun {
-		result = append(result, mapDefault(fmt.Sprintf("Parameter %s : %s.", fun.GetID().ToMappedString(coqMapConnectors(), false), fun.GetTypeHint().ToString())))
+		result = append(result, mapDefault(fmt.Sprintf("Parameter %s : %s.",
+			fun.GetID().ToMappedString(rocqMapConnectors(), false), fun.GetTypeHint().ToString())))
 		for _, term := range fun.GetArgs().GetSlice() {
 			result = append(result, clean(result, getContextFromTerm(term))...)
 		}
@@ -160,7 +162,7 @@ func clean(set, add []string) []string {
 func contextualizeMetas(metaList Lib.List[AST.Meta]) string {
 	result := []string{}
 	for _, meta := range metaList.GetSlice() {
-		result = append(result, meta.ToMappedString(coqMapConnectors(), false))
+		result = append(result, meta.ToMappedString(rocqMapConnectors(), false))
 	}
 	return "Parameters " + strings.Join(result, " ") + " : goeland_U."
 }

--- a/src/Mods/rocq/output.go
+++ b/src/Mods/rocq/output.go
@@ -31,10 +31,10 @@
 **/
 
 /**
-* This file provides a coq output for Goeland's proofs.
+* This file provides a rocq output for Goeland's proofs.
 **/
 
-package coq
+package rocq
 
 import (
 	"strings"
@@ -48,38 +48,38 @@ import (
 
 var contextEnabled bool = false
 
-var CoqOutputProofStruct = &Search.OutputProofStruct{ProofOutput: MakeCoqOutput, Name: "Coq", Extension: ".v"}
+var RocqOutputProofStruct = &Search.OutputProofStruct{ProofOutput: MakeRocqOutput, Name: "Rocq", Extension: ".v"}
 
 // ----------------------------------------------------------------------------
 // Plugin initialisation and main function to call.
 
 // Section: init
-// Functions: MakeCoqOutput
-// Main functions of the coq module.
+// Functions: MakeRocqOutput
+// Main functions of the rocq module.
 // TODO:
 //	* Write the context for TFF problems
 
-func MakeCoqOutput(prf []Search.ProofStruct, meta Lib.List[AST.Meta]) string {
+func MakeRocqOutput(prf []Search.ProofStruct, meta Lib.List[AST.Meta]) string {
 	if len(prf) == 0 {
-		Glob.PrintError("Coq", "Nothing to output")
+		Glob.PrintError("Rocq", "Nothing to output")
 		return ""
 	}
 
 	// Transform tableaux's proof in GS3 proof
-	return MakeCoqProof(gs3.MakeGS3Proof(prf), meta)
+	return MakeRocqProof(gs3.MakeGS3Proof(prf), meta)
 }
 
-var MakeCoqProof = func(proof *gs3.GS3Sequent, meta Lib.List[AST.Meta]) string {
+var MakeRocqProof = func(proof *gs3.GS3Sequent, meta Lib.List[AST.Meta]) string {
 	contextString := makeContextIfNeeded(proof.GetTargetForm(), meta)
-	proofString := makeCoqProofFromGS3(proof)
+	proofString := makeRocqProofFromGS3(proof)
 	return contextString + "\n" + proofString
 }
 
-// Replace defined symbols by Coq's defined symbols.
+// Replace defined symbols by Rocq's defined symbols.
 func mapDefault(str string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(str, "$i", "goeland_U"), "$o", "Prop")
 }
-func coqMapConnectors() map[AST.FormulaType]string {
+func rocqMapConnectors() map[AST.FormulaType]string {
 	return map[AST.FormulaType]string{
 		AST.AndConn:        "/\\",
 		AST.OrConn:         "\\/",

--- a/src/Mods/rocq/proof.go
+++ b/src/Mods/rocq/proof.go
@@ -31,10 +31,10 @@
 **/
 
 /**
-* This file provides a coq proof from Goéland's proof.
+* This file provides a rocq proof from Goéland's proof.
 **/
 
-package coq
+package rocq
 
 import (
 	"fmt"
@@ -48,7 +48,7 @@ import (
 
 var dummy int
 
-func makeCoqProofFromGS3(proof *gs3.GS3Sequent) string {
+func makeRocqProofFromGS3(proof *gs3.GS3Sequent) string {
 	dummy = 0
 	axioms, conjecture := processMainFormula(proof.GetTargetForm())
 	totalAxioms := axioms.Len()
@@ -227,7 +227,8 @@ func makeTheorem(axioms *AST.FormList, conjecture AST.Form) string {
 	axiomsWithConj := axioms.Copy()
 	axiomsWithConj.Append(AST.MakerNot(AST.MakerNot(conjecture)))
 	formattedProblem := makeImpChain(axiomsWithConj)
-	return "Theorem goeland_proof_of_" + problemName + " : " + mapDefault(formattedProblem.ToMappedString(coqMapConnectors(), Glob.GetTypeProof())) + ".\n"
+	return "Theorem goeland_proof_of_" + problemName + " : " +
+		mapDefault(formattedProblem.ToMappedString(rocqMapConnectors(), Glob.GetTypeProof())) + ".\n"
 }
 
 // If [F1, F2, F3] is a formlist, then this function returns F1 -> (F2 -> F3).
@@ -240,9 +241,8 @@ func makeImpChain(forms *AST.FormList) AST.Form {
 	return form
 }
 
-// Introduces a new formula in coq's hypotheses.
+// Introduces a new formula in rocq's hypotheses.
 func introduce(f AST.Form, hypotheses *AST.FormList) (int, *AST.FormList) {
-	//PrintInfo("INTRODUCING", f.ToString())
 	index := hypotheses.Len()
 	hypotheses.Append(f)
 	return index, hypotheses
@@ -256,7 +256,7 @@ func introduceList(fl, hypotheses *AST.FormList) ([]int, *AST.FormList) {
 	return indices, hypotheses
 }
 
-// Makes a Coq's name for a new hypothesis.
+// Makes a Rocq's name for a new hypothesis.
 func introName(i int) string {
 	return fmt.Sprintf("H%d", i)
 }
@@ -297,7 +297,7 @@ func getRealConstantName(constantsCreated []AST.Term, term AST.Term) string {
 	if fun, isFun := term.(AST.Fun); isFun {
 		res := ""
 		if isGroundTerm(fun.GetID()) {
-			res = fun.GetID().ToMappedString(coqMapConnectors(), Glob.GetTypeProof())
+			res = fun.GetID().ToMappedString(rocqMapConnectors(), Glob.GetTypeProof())
 			subterms := make([]string, 0)
 			for _, t := range fun.GetArgs().GetSlice() {
 				subterms = append(subterms, getRealConstantName(constantsCreated, t))
@@ -321,7 +321,7 @@ func findInConstants(constantsCreated []AST.Term, term AST.Term) string {
 		return getConstantName(term.(AST.Fun).GetID())
 	}
 	if isGroundTerm(term) {
-		return "(" + term.ToMappedString(coqMapConnectors(), Glob.GetTypeProof()) + ")"
+		return "(" + term.ToMappedString(rocqMapConnectors(), Glob.GetTypeProof()) + ")"
 	}
 	return "goeland_I"
 }

--- a/src/Search/destructive.go
+++ b/src/Search/destructive.go
@@ -100,15 +100,16 @@ func (ds *destructiveSearch) doOneStep(limit int, formula AST.Form) (bool, int) 
 	// proof.ResetProofFile()
 	ResetExchangesFile()
 
-	Glob.PrintInfo("MAIN", fmt.Sprintf("nb_step : %v - limit : %v", Glob.GetNbStep(), limit))
-
 	tp := Unif.NewNode()
 	tn := Unif.NewNode()
 
 	state := MakeState(limit, tp, tn, formula)
 	state.SetCurrentProofNodeId(0)
 
-	Glob.PrintInfo("MAIN", fmt.Sprintf("Launch Gotab with destructive = %v", Glob.IsDestructive()))
+	Glob.PrintInfo(
+		"search",
+		fmt.Sprintf("Launching destructive search with reintroduction limit set to %d.", limit),
+	)
 
 	Glob.SetNbGoroutines(0)
 	state.SetLF(Core.MakeSingleElementFormAndTermList(Core.MakeFormAndTerm(

--- a/src/main.go
+++ b/src/main.go
@@ -63,7 +63,7 @@ import (
 )
 
 var chAssistant chan bool = make(chan bool)
-var main_label = "Main"
+var main_label = "main"
 var debug Glob.Debugger
 
 func printChrono(id string, start time.Time) {
@@ -124,10 +124,15 @@ func presearchLoader() (AST.Form, int) {
 	problem := os.Args[len(os.Args)-1]
 	Glob.SetProblemName(path.Base(problem))
 
-	fmt.Printf("You are running Goeland v.%v\n", Glob.GetVersion())
-	fmt.Printf("Problem: %v\n", Glob.GetProblemName())
-
-	Glob.PrintInfo(main_label, fmt.Sprintf("Problem : %v", problem))
+	Glob.PrintInfo(
+		"preloader",
+		fmt.Sprintf("You are running problem %s on Goeland v.%s", path.Base(problem), Glob.GetVersion()),
+	)
+	debug(
+		Lib.MkLazy(func() string {
+			return fmt.Sprintf("Full problem path: %s", problem)
+		}),
+	)
 
 	statements, bound, containsEquality := Parser.ParseTPTPFile(problem)
 	actualStatements := Engine.ToInternalSyntax(statements)
@@ -364,9 +369,9 @@ func checkForTypedProof(form AST.Form) AST.Form {
 		err := Typing.WellFormedVerification(form.Copy(), Glob.GetTypeProof())
 
 		if err != nil {
-			Glob.Fatal(main_label, fmt.Sprintf("Typing error: %v", err))
+			Glob.Fatal("typechecker", fmt.Sprintf("Typing error: %v", err))
 		} else {
-			Glob.PrintInfo(main_label, "Well typed.")
+			Glob.PrintInfo("typechecker", fmt.Sprintf("The problem %s is well typed.", Glob.GetProblemName()))
 		}
 	}
 

--- a/src/options.go
+++ b/src/options.go
@@ -11,12 +11,12 @@ import (
 	"github.com/GoelandProver/Goeland/Glob"
 	"github.com/GoelandProver/Goeland/Lib"
 	"github.com/GoelandProver/Goeland/Mods/assisted"
-	"github.com/GoelandProver/Goeland/Mods/coq"
 	"github.com/GoelandProver/Goeland/Mods/dmt"
 	equality "github.com/GoelandProver/Goeland/Mods/equality/bse"
 	"github.com/GoelandProver/Goeland/Mods/equality/sateq"
 	"github.com/GoelandProver/Goeland/Mods/gs3"
 	"github.com/GoelandProver/Goeland/Mods/lambdapi"
+	"github.com/GoelandProver/Goeland/Mods/rocq"
 	"github.com/GoelandProver/Goeland/Mods/tptp"
 	"github.com/GoelandProver/Goeland/Search"
 	"github.com/GoelandProver/Goeland/Search/incremental"
@@ -255,13 +255,13 @@ func buildOptions() {
 		func(bool) { Glob.SetCompleteness(true) },
 		func(bool) {})
 	(&option[bool]{}).init(
-		"ocoq",
+		"orocq",
 		false,
-		"Enables the Coq format for proofs instead of text",
+		"Enables the Rocq format for proofs instead of text",
 		func(bool) {
-			Glob.OutputCoq()
+			Glob.OutputRocq()
 			Glob.SetProof(true)
-			Search.AddPrintProofAlgorithm(coq.CoqOutputProofStruct)
+			Search.AddPrintProofAlgorithm(rocq.RocqOutputProofStruct)
 		},
 		func(bool) {})
 	(&option[bool]{}).init(
@@ -299,8 +299,8 @@ func buildOptions() {
 	(&option[bool]{}).init(
 		"context",
 		false,
-		"Should only be used with the -ocoq or the -olp parameters. Enables the context for a standalone execution",
-		func(bool) { coq.SetContextEnabled(true) },
+		"Should only be used with the -orocq or the -olp parameters. Enables the context for a standalone execution",
+		func(bool) { rocq.SetContextEnabled(true) },
 		func(bool) {})
 	(&option[bool]{}).init(
 		"inner",
@@ -357,7 +357,7 @@ func buildOptions() {
 	(&option[bool]{}).init(
 		"chrono",
 		false,
-		"Should only be used with the -ocoq, the -olp or the otptp parameters. Enables the chronometer for deskolemization and proof translation",
+		"Should only be used with the -orocq, the -olp or the otptp parameters. Enables the chronometer for deskolemization and proof translation",
 		func(bool) {
 			chronoInit()
 		},
@@ -422,11 +422,11 @@ func buildOptions() {
 }
 
 func chronoInit() {
-	oldCoq := coq.MakeCoqProof
-	coq.MakeCoqProof = func(proof *gs3.GS3Sequent, meta Lib.List[AST.Meta]) string {
+	old_rocq := rocq.MakeRocqProof
+	rocq.MakeRocqProof = func(proof *gs3.GS3Sequent, meta Lib.List[AST.Meta]) string {
 		start := time.Now()
-		result := oldCoq(proof, meta)
-		printChrono("Coq", start)
+		result := old_rocq(proof, meta)
+		printChrono("Rocq", start)
 		return result
 	}
 


### PR DESCRIPTION
<!-- Feel free to delete the parts that you don't need. -->

# Bug fix

Closes: #20 

# Description

Bump `-ocoq` to `-orocq` in the options & in the various documentation files. Also updated internal names to `Rocq/rocq` instead of `Coq`.

Cleaned up the pre-search display (e.g., removed the *very* outdated message that told "launch gotab with..."). 
