### PR TITLE
Fix test-suite script to avoid returning if exit code isn't specified

### DIFF
--- a/devtools/run-test-suite.py
+++ b/devtools/run-test-suite.py
@@ -71,12 +71,13 @@ def runWithExpected(f, parser):
             else:
                 return
 
-    if parser.expectedExitCode != '' and int(parser.expectedExitCode) != exit_code:
-        print(f"Error: expected exit code '{parser.expectedExitCode}', got: '{exit_code}'")
-        exit(1)
-    else: return
+    if parser.expectedExitCode != '':
+        if int(parser.expectedExitCode) != exit_code:
+            print(f"Error: expected exit code '{parser.expectedExitCode}', got: '{exit_code}'")
+            exit(1)
+        else: return
 
-    print(f"Unknown error: {output}")
+    print(f"Unknown error: got\n{output}")
     exit(1)
 
 def compareOutputs(f, parser):


### PR DESCRIPTION
Fix of a bug introduced in #43 to account for exit codes in the test-suite script. This early return made it impossible to catch unexpected errors. Fortunately, it seems that nothing was affected in the master branch.