### PR TITLE
Fix Full CI runs

### DIFF
--- a/.github/workflows/full-ci-remove-label.yml
+++ b/.github/workflows/full-ci-remove-label.yml
@@ -1,0 +1,22 @@
+name: Full CI Remove Labels
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  RemoveLabel:
+    if: github.event.label.name == 'request:ci'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mondeja/remove-labels-gh-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            request:ci
+			needs:ci

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -1,12 +1,7 @@
 name: Full CI
 
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
-
 on:
-  pull_request_target:
+  pull_request:
     types: [labeled]
 
 env:
@@ -15,16 +10,6 @@ env:
   GOMAXPROCS: '3'
 
 jobs:
-  RemoveLabel:
-    if: github.event.label.name == 'request:ci'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mondeja/remove-labels-gh-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            request:ci
-
   UnitTests:
     if: github.event.label.name == 'request:ci'
     runs-on: ubuntu-latest
@@ -95,20 +80,3 @@ jobs:
       - run: go install golang.org/x/tools/cmd/goyacc@latest
       - run: cd src && make
       - run: cd devtools && make test-suite
-
-  RemoveNeedsCIIfSucceed:
-    needs:
-      - TestSuite
-      - UnitTests
-      - VanillaSoundness
-      - InnerSoundness
-      - PreInnerSoundness
-      - DMTSoundness
-    runs-on: ubuntu-latest
-    steps:
-      - uses: mondeja/remove-labels-gh-action@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          labels: |
-            needs:ci
-


### PR DESCRIPTION
<!-- Feel free to delete the parts that you don't need. -->

# Description

In the full CI configuration file, the target was `pull_request_target` which effectively gave it the rights to unlabel things. Unfortunately, it also meant testing an old version of `Goeland` as it checked out the master branch instead of the branch of the PR. This modification should fix it.
