### PR TITLE
CI: use actual head of PR instead of merge head in full CI

### DIFF
--- a/.github/workflows/full-ci-remove-label.yml
+++ b/.github/workflows/full-ci-remove-label.yml
@@ -19,4 +19,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
             request:ci
-			needs:ci
+            needs:ci

--- a/.github/workflows/full-ci.yml
+++ b/.github/workflows/full-ci.yml
@@ -14,7 +14,9 @@ jobs:
     if: github.event.label.name == 'request:ci'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v3
         with:
           go-version: '>=1.22.0'
@@ -25,7 +27,9 @@ jobs:
     if: github.event.label.name == 'request:ci'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}
@@ -37,7 +41,9 @@ jobs:
     if: github.event.label.name == 'request:ci'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}
@@ -49,7 +55,9 @@ jobs:
     if: github.event.label.name == 'request:ci'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}
@@ -61,7 +69,9 @@ jobs:
     if: github.event.label.name == 'request:ci'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}
@@ -73,7 +83,9 @@ jobs:
     if: github.event.label.name == 'request:ci'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-go@v3
         with:
           go-version: ${{ env.goVersion }}


### PR DESCRIPTION
Should fix the checkout to the wrong commit in the full CI script (leading to not actually testing the PR's version of the code). Should also fix the remove label stuff that wasn't applied.

EDIT: after verification, we indeed get the right commit.